### PR TITLE
ci: add foundation files — .gitignore, CI workflows, Makefile

### DIFF
--- a/.github/workflows/check-no-corp.yml
+++ b/.github/workflows/check-no-corp.yml
@@ -1,0 +1,39 @@
+name: Check No Corp Files
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  check-no-corp:
+    name: Ensure no corp files in PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for corp files
+        run: |
+          echo "Checking for corp-specific files..."
+
+          FOUND=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | \
+            grep -E '(^|/)corp/' || true)
+
+          if [[ -n "${FOUND}" ]]; then
+            echo "ERROR: Corp files detected in PR:"
+            echo "${FOUND}"
+            echo ""
+            echo "Corp-specific configs must stay in the private gpu-mon-corp repo."
+            exit 1
+          fi
+
+          echo "OK: No corp files found."
+
+      - name: Verify .gitignore covers corp paths
+        run: |
+          grep -q "environments/corp/" .gitignore || {
+            echo "ERROR: .gitignore missing 'environments/corp/' entry"
+            exit 1
+          }
+          echo "OK: .gitignore corp entries present."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  helm-lint:
+    name: Helm chart lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Lint charts
+        run: |
+          for chart in charts/*/; do
+            if [[ -f "${chart}/Chart.yaml" ]]; then
+              echo "Linting ${chart}..."
+              helm lint "${chart}"
+            fi
+          done
+
+  python-lint:
+    name: Python source lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Lint
+        run: ruff check src/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# ═══════════════════════════════════════
+# Corp environment (managed in separate private repo)
+# NEVER commit these — they are symlinked at deploy time
+# ═══════════════════════════════════════
+environments/corp/
+ansible/inventory/corp*
+alerting/alertmanager/corp*
+
+# ═══════════════════════════════════════
+# Secrets / sensitive data
+# ═══════════════════════════════════════
+*.secret
+*.secret.yaml
+.env.corp
+**/secrets/
+.env.local
+
+# ═══════════════════════════════════════
+# Build artifacts
+# ═══════════════════════════════════════
+airgap-bundle/
+*.tar.gz
+
+# ═══════════════════════════════════════
+# General
+# ═══════════════════════════════════════
+.DS_Store
+*.swp
+*.swo
+*~
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.venv/
+venv/
+dist/
+build/
+*.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+.PHONY: help dev-up dev-down homelab-diff homelab-sync build-images lint
+
+REGISTRY ?= ghcr.io/yoonsungnam/gpu-mon
+TAG      ?= dev
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+# ─── macbook (Docker Compose) ────────────────────────────────────────────────
+
+dev-up: ## Start full stack locally (macbook env, Docker Compose)
+	docker compose -f compose/docker-compose.yaml up -d
+
+dev-down: ## Stop local stack
+	docker compose -f compose/docker-compose.yaml down
+
+dev-logs: ## Tail logs from local stack
+	docker compose -f compose/docker-compose.yaml logs -f
+
+dev-ps: ## Show running containers
+	docker compose -f compose/docker-compose.yaml ps
+
+# ─── homelab (K8s + Helmfile) ────────────────────────────────────────────────
+
+homelab-diff: ## Show pending Helm changes for homelab env
+	helmfile -e homelab diff
+
+homelab-sync: ## Deploy to homelab K8s cluster
+	helmfile -e homelab sync
+
+homelab-destroy: ## Destroy homelab deployment (irreversible)
+	helmfile -e homelab destroy
+
+# ─── corp (requires private repo symlinked) ──────────────────────────────────
+
+corp-diff: ## Show pending Helm changes for corp env (requires gpu-mon-corp symlink)
+	helmfile -e corp diff
+
+corp-sync: ## Deploy to corp K8s cluster
+	helmfile -e corp sync
+
+corp-bundle: ## Generate Airgap bundle for corp deployment
+	./scripts/airgap-bundle.sh
+
+# ─── Images ──────────────────────────────────────────────────────────────────
+
+build-images: ## Build all custom Docker images
+	./scripts/build-images.sh $(REGISTRY) $(TAG)
+
+push-images: ## Push images to registry
+	./scripts/build-images.sh $(REGISTRY) $(TAG) --push
+
+# ─── Validate ────────────────────────────────────────────────────────────────
+
+validate: ## Run deployment validation checks
+	./scripts/validate-deployment.sh
+
+lint: ## Lint Helm charts and Helmfile
+	helm lint charts/vmagent-central
+	helm lint charts/metadata-collector
+	helm lint charts/mock-dcgm-exporter
+	helmfile -e homelab lint


### PR DESCRIPTION
## Summary
- `.gitignore`: block corp/ paths, Python/Docker/Helm artifacts
- `check-no-corp.yml`: CI gate to prevent corp files in public repo
- `lint.yml`: Helm chart lint + Python ruff lint
- `Makefile`: dev-up/down, homelab-diff/sync convenience targets

Split from #1 (feat/initial-scaffolding) — PR 1/10

## Test plan
- [ ] CI workflows pass on this PR
- [ ] `.gitignore` entries verified against repo rules