### PR TITLE
feat: add ClickHouse schemas and dashboards README

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -1,0 +1,14 @@
+# Grafana Dashboards
+
+Grafana dashboard JSON files for gpu-mon.
+
+| File | Description |
+|---|---|
+| `gpu-overview.json` | Cluster-wide GPU utilization, temperature, power |
+| `gpu-efficiency.json` | L2 efficiency: Tensor Core, SM Occupancy, DRAM BW |
+| `inference-servers.json` | vLLM/TGI/Triton: TTFT, TPOT, KV Cache, throughput |
+| `job-explorer.json` | S2 Job metadata + GPU Util join |
+| `vm-inventory.json` | VMware GPU VM inventory and ESXi host mapping |
+| `node-health.json` | Node-level system metrics (CPU, Memory, Disk, Network) |
+
+Dashboards are automatically provisioned from this directory via Grafana provisioning.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,23 @@
+# ClickHouse Schemas
+
+All DDL files for the `gpu_monitoring` database.
+
+| File | Table | Engine | Purpose |
+|---|---|---|---|
+| `gpu_unified_logs.sql` | `gpu_unified_logs` | MergeTree | Normalized logs from all environments |
+| `s2_jobs.sql` | `s2_jobs` | MergeTree | S2 batch scheduler job history (time-series) |
+| `s2_nodes.sql` | `s2_nodes` | ReplacingMergeTree | S2 node current state |
+| `s2_projects.sql` | `s2_projects` | ReplacingMergeTree | S2 project/FairShare config |
+| `s2_pools.sql` | `s2_pools` | ReplacingMergeTree | S2 logical node pool config |
+| `vmware_vm_inventory.sql` | `vmware_vm_inventory` | ReplacingMergeTree | VMware GPU VM inventory |
+
+## Apply schemas
+
+```bash
+# From gpu-mon root, against a running ClickHouse instance:
+for f in schemas/*.sql; do
+  clickhouse-client --host localhost --query "$(cat $f)"
+done
+```
+
+Replace `{cluster}` with your actual ClickHouse cluster name before applying in production.

--- a/schemas/gpu_unified_logs.sql
+++ b/schemas/gpu_unified_logs.sql
@@ -1,0 +1,23 @@
+-- gpu_unified_logs: Normalized log table for all environments.
+-- Receives data from Vector Aggregator (push from node agents).
+-- TTL: configurable via environment values.
+
+CREATE DATABASE IF NOT EXISTS gpu_monitoring ON CLUSTER '{cluster}';
+
+CREATE TABLE IF NOT EXISTS gpu_monitoring.gpu_unified_logs ON CLUSTER '{cluster}'
+(
+    timestamp   DateTime64(3)                    CODEC(Delta, ZSTD),
+    env         LowCardinality(String),           -- baremetal, k8s, vm, homelab
+    cluster_id  LowCardinality(String),
+    node_id     String,
+    gpu_id      Nullable(UInt8),
+    log_level   LowCardinality(String),           -- INFO, WARN, ERROR, FATAL
+    source      LowCardinality(String),           -- driver, scheduler, kubelet, system, nccl
+    message     String,
+    metadata    String                            -- JSON: pid, container, namespace, etc.
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (env, cluster_id, node_id, timestamp)
+TTL toDateTime(timestamp) + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;

--- a/schemas/s2_jobs.sql
+++ b/schemas/s2_jobs.sql
@@ -1,0 +1,30 @@
+-- s2_jobs: Time-series history of S2 batch scheduler jobs.
+-- Each poll inserts a new row (running/pending jobs polled every 60s).
+-- Enables: job wait time analysis, GPU-Hours calculation, per-job GPU Util JOIN.
+-- TTL: 6 months.
+
+CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_jobs ON CLUSTER '{cluster}'
+(
+    collected_at  DateTime64(3)             CODEC(Delta, ZSTD),
+    job_id        String,
+    job_name      String,
+    user_id       String,
+    team          String,
+    queue         LowCardinality(String),
+    status        LowCardinality(String),   -- running, pending, completed, failed, cancelled
+    submit_time   Nullable(DateTime64(3)),
+    start_time    Nullable(DateTime64(3)),
+    end_time      Nullable(DateTime64(3)),
+    node_list     Array(String),            -- ["gpu-node-01", "gpu-node-03"]
+    gpu_count     UInt16,
+    gpu_indices   Array(UInt8),             -- [0, 1, 2, 3]
+    cpu_count     UInt16,
+    memory_mb     UInt32,
+    exit_code     Nullable(Int32),
+    metadata      String                   -- JSON: extra fields from S2 API
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(collected_at)
+ORDER BY (status, collected_at, job_id)
+TTL toDateTime(collected_at) + INTERVAL 180 DAY
+SETTINGS index_granularity = 8192;

--- a/schemas/s2_nodes.sql
+++ b/schemas/s2_nodes.sql
@@ -1,0 +1,19 @@
+-- s2_nodes: Current state of S2 scheduler nodes.
+-- ReplacingMergeTree keeps only the latest row per node_id.
+-- Polled every 120s.
+
+CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_nodes ON CLUSTER '{cluster}'
+(
+    collected_at  DateTime64(3)           CODEC(Delta, ZSTD),
+    node_id       String,
+    status        LowCardinality(String), -- idle, alloc, drain, down
+    partition     LowCardinality(String),
+    gpu_total     UInt16,
+    gpu_allocated UInt16,
+    cpu_total     UInt16,
+    cpu_allocated UInt16,
+    metadata      String
+)
+ENGINE = ReplacingMergeTree(collected_at)
+ORDER BY node_id
+SETTINGS index_granularity = 8192;

--- a/schemas/s2_pools.sql
+++ b/schemas/s2_pools.sql
@@ -1,0 +1,16 @@
+-- s2_pools: Logical node pool configuration snapshots.
+-- ReplacingMergeTree keeps latest per pool_id.
+-- Polled every 600s.
+
+CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_pools ON CLUSTER '{cluster}'
+(
+    collected_at DateTime64(3)  CODEC(Delta, ZSTD),
+    pool_id      String,
+    pool_name    String,
+    node_list    Array(String),
+    gpu_total    UInt32,
+    metadata     String          -- JSON: scheduling policy, constraints
+)
+ENGINE = ReplacingMergeTree(collected_at)
+ORDER BY pool_id
+SETTINGS index_granularity = 8192;

--- a/schemas/s2_projects.sql
+++ b/schemas/s2_projects.sql
@@ -1,0 +1,16 @@
+-- s2_projects: FairShare project configuration snapshots.
+-- ReplacingMergeTree keeps latest per project_id.
+-- Polled every 600s.
+
+CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_projects ON CLUSTER '{cluster}'
+(
+    collected_at      DateTime64(3)  CODEC(Delta, ZSTD),
+    project_id        String,
+    project_name      String,
+    fairshare_weight  Float32,
+    gpu_limit         UInt32,
+    metadata          String         -- JSON: full project config
+)
+ENGINE = ReplacingMergeTree(collected_at)
+ORDER BY project_id
+SETTINGS index_granularity = 8192;

--- a/schemas/vmware_vm_inventory.sql
+++ b/schemas/vmware_vm_inventory.sql
@@ -1,0 +1,27 @@
+-- vmware_vm_inventory: Current GPU VM inventory from VMware vCenter.
+-- ReplacingMergeTree keeps latest per vm_uuid.
+-- Polled every 300s. TTL: 12 months.
+
+CREATE TABLE IF NOT EXISTS gpu_monitoring.vmware_vm_inventory ON CLUSTER '{cluster}'
+(
+    collected_at  DateTime64(3)           CODEC(Delta, ZSTD),
+    vm_name       String,
+    vm_uuid       String,
+    vm_status     LowCardinality(String), -- poweredOn, poweredOff, suspended
+    esxi_host     String,
+    cluster       String,
+    resource_pool String,
+    guest_os      String,
+    vcpu_count    UInt16,
+    memory_mb     UInt32,
+    gpu_count     UInt8,
+    gpu_type      LowCardinality(String), -- passthrough, vgpu
+    gpu_profile   String,
+    gpu_pci_ids   String,                 -- JSON array of PCI device IDs
+    annotation    String,
+    metadata      String                  -- JSON: datacenter, folder, etc.
+)
+ENGINE = ReplacingMergeTree(collected_at)
+ORDER BY vm_uuid
+TTL toDateTime(collected_at) + INTERVAL 365 DAY
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
## Summary
- `schemas/gpu_unified_logs.sql`: normalized log table
- `schemas/s2_jobs.sql`: S2 batch job history (MergeTree)
- `schemas/s2_nodes.sql`: S2 node state (ReplacingMergeTree)
- `schemas/s2_projects.sql`, `s2_pools.sql`: config snapshots
- `schemas/vmware_vm_inventory.sql`: GPU VM inventory
- `dashboards/README.md`: placeholder

Split from #1 — PR 2/10

## Test plan
- [ ] SQL syntax valid for ClickHouse 24.8
- [ ] Schema matches adapter field names in metadata-collector