### PR TITLE
docs: add architecture, quickstart, and deployment guides

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,60 @@
+# Architecture
+
+## Overview
+
+gpu-mon is a unified GPU monitoring platform for multi-environment clusters.
+
+```
+DATA SOURCES (per node: Exporter + lightweight Vector Agent)
+  ├── Baremetal GPU Clusters (S2 Batch Scheduler)
+  │     DCGM Exporter (:9400) + node_exporter (:9100) + Vector Agent
+  ├── K8s GPU Clusters
+  │     DCGM Exporter (DaemonSet) + node_exporter + Vector Agent + kube-state-metrics
+  └── GPU VMs (VMware vCenter)
+        DCGM Exporter (:9400) + node_exporter + Vector Agent
+
+COLLECTION LAYER (K8s)
+  ├── vmagent (Central HA)   — Pull scrapes all Exporters → VictoriaMetrics
+  ├── Vector Aggregator      — Receives log Push → normalizes → ClickHouse
+  └── Metadata Collector     — Polls S2 API + vCenter API → ClickHouse
+
+STORAGE LAYER (K8s)
+  ├── VictoriaMetrics Cluster — Time-series metrics (DCGM, node, inference)
+  └── ClickHouse Cluster      — Logs, metadata, profiling traces
+
+PRESENTATION
+  └── Grafana                 — Unified dashboards, dual data sources
+```
+
+## Key Design Decisions
+
+| ID | Decision | Rationale |
+|---|---|---|
+| D1 | vmagent over Prometheus | VictoriaMetrics ecosystem, lower resource usage |
+| D2 | Vector over Fluent Bit | Native ClickHouse sink, VRL transform language |
+| D15 | DCGM Profiling ↔ CUPTI conflict managed via L2 pause/resume | Can't run both simultaneously |
+| D18 | Hybrid Pull (metrics) + Push (logs) | Pull is natural for point-in-time metrics; logs are streams |
+| D19 | File-based Service Discovery (Ansible-managed JSON) | Decouples scrape config from Ansible, supports 100+ nodes |
+
+## Metric Depth Levels
+
+| Level | Source | Overhead | Purpose |
+|---|---|---|---|
+| L1 | DCGM basic counters | ~0% | GPU health: Util, Temp, Power, XID |
+| L2 | DCGM Profiling, inference /metrics, NCCL logs | 1-3% | Efficiency: Tensor Core, SM Occupancy, TTFT/TPOT |
+| L3 | CUPTI, Nsight | 3-20% | On-demand kernel-level profiling |
+
+## Environments
+
+| Env | Orchestration | GPU Source | Purpose |
+|---|---|---|---|
+| macbook | Docker Compose | mock-dcgm-exporter | Rapid local development |
+| homelab | K8s (Helmfile) | mock-dcgm-exporter | Integration testing |
+| corp | K8s (Helmfile) | Real DCGM + S2 + vCenter | Production (private repo) |
+
+## Two-Repo Structure
+
+Public repo (`gpu-mon`): all env-agnostic code, charts, src, schemas, dashboards.
+Private repo (`gpu-mon-corp`): corp-specific configs only, symlinked at deploy time.
+
+See [corp-deployment.md](corp-deployment.md) for the airgap deployment guide.

--- a/docs/corp-deployment.md
+++ b/docs/corp-deployment.md
@@ -1,0 +1,62 @@
+# Corp / Production Deployment Guide
+
+This guide covers deploying gpu-mon to an air-gapped corp environment.
+Actual infrastructure details live in the separate private `gpu-mon-corp` repo.
+
+## Prerequisites
+
+- `gpu-mon-corp` repo cloned alongside this repo
+- Symlinks configured (see below)
+- WSL with internet access (for bundle generation)
+
+## One-time symlink setup (WSL)
+
+```bash
+cd ~/work/gpu-mon/environments/
+ln -s ../../gpu-mon-corp/environments/corp ./corp
+
+cd ~/work/gpu-mon/ansible/inventory/
+ln -s ../../../gpu-mon-corp/ansible/inventory/corp.ini ./corp.ini
+
+cd ~/work/gpu-mon/alerting/alertmanager/
+ln -s ../../../gpu-mon-corp/alerting/alertmanager/corp.yaml ./corp.yaml
+```
+
+## Scenario A: Direct Helmfile deploy (intranet access)
+
+```bash
+cd ~/work/gpu-mon
+
+# Pull latest
+git pull
+cd ../gpu-mon-corp && git pull && cd ../gpu-mon
+
+# Preview changes
+helmfile -e corp diff
+
+# Deploy
+helmfile -e corp sync
+
+# Verify
+kubectl -n monitoring get pods
+```
+
+## Scenario B: Airgap bundle
+
+When the corp K8s cluster has no internet access:
+
+```bash
+# On WSL (internet available):
+cd ~/work/gpu-mon
+make corp-bundle
+# → gpu-mon-airgap-YYYYMMDD-HHMMSS.tar.gz
+
+# Transfer bundle to corp server, then on corp server:
+tar xzf gpu-mon-airgap-*.tar.gz
+./install.sh registry.internal.corp.com
+```
+
+## corp.example/ template
+
+`environments/corp.example/` shows the structure without real values.
+Copy to the private repo and fill in actual infrastructure details.

--- a/docs/homelab-setup.md
+++ b/docs/homelab-setup.md
@@ -1,0 +1,33 @@
+# Homelab Setup (K8s)
+
+Deploy the full stack to a local K8s cluster (k3s, kind, etc.).
+
+## Prerequisites
+
+- K8s cluster with `kubectl` configured
+- `helm` + `helmfile` + `helm-diff` plugin
+
+```bash
+./scripts/setup-homelab.sh
+```
+
+## Deploy
+
+```bash
+make homelab-diff    # preview changes
+make homelab-sync    # deploy
+```
+
+## Verify
+
+```bash
+kubectl -n monitoring get pods
+make validate
+```
+
+## Port-forward Grafana
+
+```bash
+kubectl -n monitoring port-forward svc/grafana 3000:3000
+# open http://localhost:3000
+```

--- a/docs/macbook-quickstart.md
+++ b/docs/macbook-quickstart.md
@@ -1,0 +1,49 @@
+# macbook Quickstart
+
+Get the full monitoring stack running locally in minutes, without any GPU hardware.
+
+## Prerequisites
+
+- Docker Desktop (running)
+- `make`
+
+## Start
+
+```bash
+git clone https://github.com/YoonsungNam/gpu-mon.git
+cd gpu-mon
+
+./scripts/setup-macbook.sh   # one-time check
+make dev-up
+```
+
+Open [http://localhost:3000](http://localhost:3000) — Grafana (admin / admin).
+
+## What runs
+
+| Container | Port | Description |
+|---|---|---|
+| mock-dcgm-exporter | 9400 | Synthetic GPU metrics (4 nodes × 2 GPUs) |
+| vmagent | 8429 | Scrapes mock exporter, writes to VictoriaMetrics |
+| vminsert | 8480 | VictoriaMetrics insert endpoint |
+| vmselect | 8481 | VictoriaMetrics query endpoint |
+| vmstorage | — | VictoriaMetrics storage (internal) |
+| clickhouse | 8123, 9000 | Log and metadata storage |
+| vector | 6000 | Log aggregator (accepts Vector protocol) |
+| grafana | 3000 | Dashboards |
+
+## Stop
+
+```bash
+make dev-down
+```
+
+## Useful commands
+
+```bash
+make dev-logs        # tail all container logs
+make dev-ps          # show running containers
+
+# Query metrics directly
+curl -s "http://localhost:8481/select/0/prometheus/api/v1/query?query=DCGM_FI_DEV_GPU_UTIL" | jq .
+```


### PR DESCRIPTION
## Summary
- `docs/architecture.md`: system overview, design decisions, metric depth levels
- `docs/macbook-quickstart.md`: Docker Compose local dev setup guide
- `docs/homelab-setup.md`: K8s + Helmfile integration testing guide
- `docs/corp-deployment.md`: airgap deployment guide

Split from #1 — PR 3/10

## Test plan
- Docs-only change; no runtime impact