### PR TITLE
feat: add custom Helm charts for gpu-mon components

### DIFF
--- a/charts/clickhouse-cluster/Chart.yaml
+++ b/charts/clickhouse-cluster/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: clickhouse-cluster
+description: >
+  ClickHouseInstallation CRD resource for gpu-mon.
+  Requires altinity-clickhouse-operator to be installed first.
+type: application
+version: 0.1.0
+appVersion: "24.8"
+dependencies:
+  []

--- a/charts/clickhouse-cluster/templates/clickhouseinstallation.yaml
+++ b/charts/clickhouse-cluster/templates/clickhouseinstallation.yaml
@@ -1,0 +1,34 @@
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: {{ .Values.clickhouse.cluster.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  configuration:
+    clusters:
+      - name: {{ .Values.clickhouse.cluster.name }}
+        layout:
+          shardsCount: {{ .Values.clickhouse.cluster.layout.shardsCount }}
+          replicasCount: {{ .Values.clickhouse.cluster.layout.replicasCount }}
+    settings:
+      max_connections: "4096"
+      keep_alive_timeout: "3"
+  templates:
+    podTemplates:
+      - name: default
+        spec:
+          containers:
+            - name: clickhouse
+              image: {{ .Values.clickhouse.image }}
+              resources:
+                {{- toYaml .Values.clickhouse.resources | nindent 16 }}
+    volumeClaimTemplates:
+      - name: default
+        spec:
+          {{- if .Values.clickhouse.storage.storageClassName }}
+          storageClassName: {{ .Values.clickhouse.storage.storageClassName }}
+          {{- end }}
+          accessModes: [ReadWriteOnce]
+          resources:
+            requests:
+              storage: {{ .Values.clickhouse.storage.size }}

--- a/charts/clickhouse-cluster/values.yaml
+++ b/charts/clickhouse-cluster/values.yaml
@@ -1,0 +1,21 @@
+clickhouse:
+  cluster:
+    name: gpu-monitoring
+    layout:
+      shardsCount: 1
+      replicasCount: 1
+  image: clickhouse/clickhouse-server:24.8
+  storage:
+    size: 20Gi
+    storageClassName: ""   # Use default SC if empty
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 2
+      memory: 4Gi
+
+schema_init:
+  enabled: true
+  image: clickhouse/clickhouse-client:24.8

--- a/charts/metadata-collector/Chart.yaml
+++ b/charts/metadata-collector/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: metadata-collector
+description: >
+  Polls legacy system APIs (Samsung S2 batch scheduler, VMware vCenter)
+  and ingests metadata into ClickHouse for enrichment with GPU metrics.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/metadata-collector/templates/_helpers.tpl
+++ b/charts/metadata-collector/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{- define "metadata-collector.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "metadata-collector.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "metadata-collector.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "metadata-collector.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "metadata-collector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metadata-collector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/metadata-collector/templates/configmap.yaml
+++ b/charts/metadata-collector/templates/configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "metadata-collector.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metadata-collector.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    collector:
+      log_level: {{ .Values.config.logLevel }}
+      health_port: {{ .Values.config.healthPort }}
+
+    clickhouse:
+      endpoints:
+        - {{ .Values.config.clickhouse.host }}:{{ .Values.config.clickhouse.port }}
+      database: {{ .Values.config.clickhouse.database }}
+      username: {{ .Values.config.clickhouse.username }}
+      batch_size: {{ .Values.config.clickhouse.batchSize }}
+      flush_interval: {{ .Values.config.clickhouse.flushInterval }}
+
+    sources:
+      s2:
+        enabled: {{ .Values.config.sources.s2.enabled }}
+      vmware:
+        enabled: {{ .Values.config.sources.vmware.enabled }}

--- a/charts/metadata-collector/templates/deployment.yaml
+++ b/charts/metadata-collector/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "metadata-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metadata-collector.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "metadata-collector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "metadata-collector.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: metadata-collector
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: health
+              containerPort: {{ .Values.config.healthPort }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/metadata-collector
+          env:
+            {{- if .Values.existingSecrets.s2ApiToken }}
+            - name: S2_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecrets.s2ApiToken }}
+                  key: token
+            {{- end }}
+            {{- if .Values.existingSecrets.vcenterCredentials }}
+            - name: VCENTER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecrets.vcenterCredentials }}
+                  key: username
+            - name: VCENTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecrets.vcenterCredentials }}
+                  key: password
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "metadata-collector.fullname" . }}-config

--- a/charts/metadata-collector/values.yaml
+++ b/charts/metadata-collector/values.yaml
@@ -1,0 +1,46 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/yoonsungnam/gpu-mon/metadata-collector
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# Configuration is mounted from a ConfigMap + Secrets
+config:
+  logLevel: info
+  healthPort: 8080
+
+  clickhouse:
+    host: clickhouse.clickhouse.svc
+    port: 9000
+    database: gpu_monitoring
+    username: metadata_writer
+    batchSize: 500
+    flushInterval: "10s"
+
+  sources:
+    s2:
+      enabled: false
+      # Set via Secret: s2-api-token
+      # apiUrl: "http://s2-master.internal:8080/api/v1"
+    vmware:
+      enabled: false
+      # Set via Secret: vcenter-credentials
+      # vcenterUrl: "https://vcenter.internal.example.com"
+
+# Existing secret names (created separately, not by this chart)
+existingSecrets:
+  s2ApiToken: ""         # Key: token
+  vcenterCredentials: "" # Keys: username, password
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/charts/mock-dcgm-exporter/Chart.yaml
+++ b/charts/mock-dcgm-exporter/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: mock-dcgm-exporter
+description: >
+  Mock DCGM Exporter for gpu-mon development environments.
+  Generates realistic synthetic GPU metrics (L1 + L2) without real GPUs.
+  Used in macbook (Docker Compose) and homelab (K8s) environments.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/mock-dcgm-exporter/templates/_helpers.tpl
+++ b/charts/mock-dcgm-exporter/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{- define "mock-dcgm-exporter.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "mock-dcgm-exporter.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "mock-dcgm-exporter.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "mock-dcgm-exporter.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "mock-dcgm-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mock-dcgm-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/mock-dcgm-exporter/templates/deployment.yaml
+++ b/charts/mock-dcgm-exporter/templates/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mock-dcgm-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mock-dcgm-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mock-dcgm-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mock-dcgm-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: mock-dcgm-exporter
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: NODE_COUNT
+              value: "{{ .Values.nodeCount }}"
+            - name: GPUS_PER_NODE
+              value: "{{ .Values.gpusPerNode }}"
+            - name: GPU_MODEL
+              value: "{{ .Values.gpuModel }}"
+            - name: SCRAPE_INTERVAL
+              value: "{{ .Values.scrapeInterval }}"
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/mock-dcgm-exporter/templates/service.yaml
+++ b/charts/mock-dcgm-exporter/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mock-dcgm-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mock-dcgm-exporter.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.service.port }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "mock-dcgm-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/mock-dcgm-exporter/values.yaml
+++ b/charts/mock-dcgm-exporter/values.yaml
@@ -1,0 +1,26 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/yoonsungnam/gpu-mon/mock-dcgm-exporter
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# Simulated GPU topology
+nodeCount: 2
+gpusPerNode: 2
+gpuModel: "A100"
+
+# Metric update interval (seconds)
+scrapeInterval: 15
+
+service:
+  type: ClusterIP
+  port: 9400
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi

--- a/charts/vmagent-central/Chart.yaml
+++ b/charts/vmagent-central/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: vmagent-central
+description: >
+  Central vmagent deployment for gpu-mon.
+  Pulls metrics from all node exporters (File SD + K8s SD)
+  and remote_writes to VictoriaMetrics.
+type: application
+version: 0.1.0
+appVersion: "v1.106.1"

--- a/charts/vmagent-central/templates/_helpers.tpl
+++ b/charts/vmagent-central/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vmagent-central.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "vmagent-central.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "vmagent-central.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "vmagent-central.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "vmagent-central.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vmagent-central.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/vmagent-central/templates/configmap.yaml
+++ b/charts/vmagent-central/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vmagent-central.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vmagent-central.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.scrapeConfig | nindent 4 }}

--- a/charts/vmagent-central/templates/deployment.yaml
+++ b/charts/vmagent-central/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vmagent-central.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vmagent-central.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vmagent-central.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vmagent-central.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "vmagent-central.fullname" . }}
+      containers:
+        - name: vmagent
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-promscrape.config=/etc/vmagent/config.yaml"
+            {{- range .Values.remoteWrite }}
+            - "-remoteWrite.url={{ .url }}"
+            {{- end }}
+            - "-httpListenAddr=:{{ .Values.service.port }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/vmagent
+            {{- if .Values.fileSD.enabled }}
+            - name: file-sd
+              mountPath: /etc/vmagent/sd
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "vmagent-central.fullname" . }}-config
+        {{- if .Values.fileSD.enabled }}
+        - name: file-sd
+          configMap:
+            name: {{ .Values.fileSD.configMapName }}
+        {{- end }}

--- a/charts/vmagent-central/templates/service.yaml
+++ b/charts/vmagent-central/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vmagent-central.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vmagent-central.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "vmagent-central.selectorLabels" . | nindent 4 }}

--- a/charts/vmagent-central/templates/serviceaccount.yaml
+++ b/charts/vmagent-central/templates/serviceaccount.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vmagent-central.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vmagent-central.labels" . | nindent 4 }}
+---
+# ClusterRole for K8s service discovery
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vmagent-central.fullname" . }}
+  labels:
+    {{- include "vmagent-central.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: [nodes, nodes/proxy, nodes/metrics, services, endpoints, pods]
+    verbs: [get, list, watch]
+  - nonResourceURLs: [/metrics, /metrics/cadvisor]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vmagent-central.fullname" . }}
+  labels:
+    {{- include "vmagent-central.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "vmagent-central.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "vmagent-central.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/vmagent-central/values.yaml
+++ b/charts/vmagent-central/values.yaml
@@ -1,0 +1,36 @@
+replicaCount: 1
+
+image:
+  repository: victoriametrics/vmagent
+  tag: "v1.106.1"
+  pullPolicy: IfNotPresent
+
+# remote_write targets
+remoteWrite:
+  - url: "http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
+
+# Full vmagent scrape configuration (merged by environment values)
+scrapeConfig: {}
+
+# File SD config map: Ansible-managed JSON target files
+# Keys are mounted as /etc/vmagent/sd/<key>
+fileSD:
+  enabled: false
+  configMapName: vmagent-file-sd
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+service:
+  type: ClusterIP
+  port: 8429
+
+# vmagent UI ingress (optional)
+ingress:
+  enabled: false
+  host: ""


### PR DESCRIPTION
## Summary
Four custom Helm charts for components without suitable OSS charts:
- `charts/vmagent-central/`: central vmagent with File SD support, RBAC
- `charts/mock-dcgm-exporter/`: mock GPU exporter for dev environments
- `charts/metadata-collector/`: metadata collector deployment + configmap
- `charts/clickhouse-cluster/`: ClickHouseInstallation CRD resource

Split from #1 — PR 6/10

## Test plan
- [ ] `helm lint charts/*` passes for all 4 charts
- [ ] `helm template` renders valid K8s manifests