### PR TITLE
feat: add Docker Compose stack and macbook environment config

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -1,0 +1,125 @@
+---
+# gpu-mon macbook development stack (Docker Compose)
+# No K8s required. Uses mock DCGM exporter for synthetic GPU metrics.
+#
+# Usage:
+#   make dev-up      # start
+#   make dev-down    # stop
+#   make dev-logs    # tail logs
+
+name: gpu-mon
+
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+services:
+  # ── Mock DCGM Exporter ─────────────────────────────────────────────────────
+  mock-dcgm-exporter:
+    build:
+      context: ../src/mock-dcgm-exporter
+    environment:
+      NODE_COUNT: "4"
+      GPUS_PER_NODE: "2"
+      GPU_MODEL: "A100"
+      SCRAPE_INTERVAL: "15"
+    ports:
+      - "9400:9400"
+    logging: *default-logging
+
+  # ── Central vmagent ────────────────────────────────────────────────────────
+  vmagent:
+    image: victoriametrics/vmagent:v1.106.1
+    command:
+      - "-promscrape.config=/etc/vmagent/config.yaml"
+      - "-remoteWrite.url=http://vminsert:8480/insert/0/prometheus/"
+      - "-httpListenAddr=:8429"
+    volumes:
+      - ./vmagent-config.yaml:/etc/vmagent/config.yaml:ro
+    ports:
+      - "8429:8429"
+    depends_on:
+      - mock-dcgm-exporter
+      - vminsert
+    logging: *default-logging
+
+  # ── VictoriaMetrics Cluster ────────────────────────────────────────────────
+  vmstorage:
+    image: victoriametrics/vmstorage:v1.106.1
+    command:
+      - "-storageDataPath=/vmstorage-data"
+      - "-retentionPeriod=7d"
+    volumes:
+      - vmstorage-data:/vmstorage-data
+    logging: *default-logging
+
+  vminsert:
+    image: victoriametrics/vminsert:v1.106.1
+    command:
+      - "-storageNode=vmstorage:8400"
+    ports:
+      - "8480:8480"
+    depends_on:
+      - vmstorage
+    logging: *default-logging
+
+  vmselect:
+    image: victoriametrics/vmselect:v1.106.1
+    command:
+      - "-storageNode=vmstorage:8401"
+    ports:
+      - "8481:8481"
+    depends_on:
+      - vmstorage
+    logging: *default-logging
+
+  # ── ClickHouse ─────────────────────────────────────────────────────────────
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8
+    ports:
+      - "8123:8123"   # HTTP
+      - "9000:9000"   # Native
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+      - ../schemas:/docker-entrypoint-initdb.d:ro
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    logging: *default-logging
+
+  # ── Vector Aggregator ──────────────────────────────────────────────────────
+  vector:
+    image: timberio/vector:0.42.0-alpine
+    command: ["--config", "/etc/vector/vector.toml"]
+    volumes:
+      - ./vector-aggregator.toml:/etc/vector/vector.toml:ro
+    ports:
+      - "6000:6000"
+    depends_on:
+      - clickhouse
+    logging: *default-logging
+
+  # ── Grafana ────────────────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:11.4.0
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana-provisioning:/etc/grafana/provisioning:ro
+      - ../dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - vmselect
+      - clickhouse
+    logging: *default-logging
+
+volumes:
+  vmstorage-data:
+  clickhouse-data:
+  grafana-data:

--- a/compose/grafana-provisioning/dashboards/dashboards.yaml
+++ b/compose/grafana-provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: gpu-mon
+    orgId: 1
+    folder: GPU Monitoring
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/compose/grafana-provisioning/datasources/datasources.yaml
+++ b/compose/grafana-provisioning/datasources/datasources.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+datasources:
+  - name: VictoriaMetrics
+    type: prometheus
+    url: http://vmselect:8481/select/0/prometheus
+    isDefault: true
+    access: proxy
+
+  - name: ClickHouse
+    type: grafana-clickhouse-datasource
+    url: http://clickhouse:8123
+    jsonData:
+      host: clickhouse
+      port: 8123
+      defaultDatabase: gpu_monitoring

--- a/compose/vector-aggregator.toml
+++ b/compose/vector-aggregator.toml
@@ -1,0 +1,24 @@
+[sources.vector_in]
+type = "vector"
+address = "0.0.0.0:6000"
+
+[transforms.standardize]
+type = "remap"
+inputs = ["vector_in"]
+source = '''
+  .log_level = upcase(string!(.level ?? "INFO"))
+  .source    = string!(.source ?? "system")
+  .metadata  = encode_json(.metadata ?? {})
+'''
+
+[sinks.clickhouse]
+type = "clickhouse"
+inputs = ["standardize"]
+endpoint = "http://clickhouse:8123"
+database = "gpu_monitoring"
+table = "gpu_unified_logs"
+compression = "gzip"
+
+[sinks.clickhouse.batch]
+max_bytes = 10485760
+timeout_secs = 10

--- a/compose/vmagent-config.yaml
+++ b/compose/vmagent-config.yaml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "mock-dcgm"
+    static_configs:
+      - targets:
+          - "mock-dcgm-exporter:9400"
+        labels:
+          env: homelab
+          cluster: macbook
+          workload_type: training

--- a/environments/macbook/.env.example
+++ b/environments/macbook/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env.local and fill in as needed.
+# These are only used for macbook Docker Compose.
+
+GRAFANA_ADMIN_PASSWORD=admin
+CLICKHOUSE_PASSWORD=
+VM_RETENTION_PERIOD=7d

--- a/environments/macbook/values.yaml
+++ b/environments/macbook/values.yaml
@@ -1,0 +1,23 @@
+# macbook environment — Docker Compose only, no K8s
+# Run with: make dev-up
+#
+# Uses mock DCGM exporter to simulate GPU metrics.
+
+image_registry: ghcr.io/yoonsungnam/gpu-mon
+image_tag: dev
+
+mock_dcgm:
+  enabled: true
+  node_count: 4      # Simulated GPU nodes
+  gpus_per_node: 2   # GPUs per simulated node
+  gpu_model: A100
+
+# Local ports exposed on host
+ports:
+  grafana: 3000
+  vminsert: 8480
+  vmselect: 8481
+  vmstorage: 8482
+  vmagent_ui: 8429
+  clickhouse_http: 8123
+  vector: 6000


### PR DESCRIPTION
## Summary
- `compose/docker-compose.yaml`: full local dev stack
- `compose/vmagent-config.yaml`: scrape config targeting mock exporter
- `compose/vector-aggregator.toml`: log pipeline to ClickHouse
- `compose/grafana-provisioning/`: auto-provisioned datasources
- `environments/macbook/`: env values for local development

Split from #1 — PR 7/10

## Test plan
- [ ] `make dev-up` starts all containers
- [ ] `curl localhost:9400/metrics` returns mock GPU metrics
- [ ] Grafana accessible at localhost:3000