### PR TITLE
feat: add Helmfile orchestration and environment configs

### DIFF
--- a/environments/corp.example/README.md
+++ b/environments/corp.example/README.md
@@ -1,0 +1,28 @@
+# Production Environment Template
+
+This directory is a **template** showing how to configure gpu-mon for a production or air-gapped environment.
+
+Actual production values live in a separate private repo and are symlinked here at deploy time. See [docs/extending-to-production.md](../../docs/extending-to-production.md) for the full guide.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `values.yaml.example` | Environment-level variables (registry, feature flags) |
+| `vmagent.yaml.example` | Central vmagent scrape configuration overrides |
+| `targets/gpu-nodes.json.example` | File SD target list for Baremetal/VM GPU nodes |
+
+## Usage
+
+```bash
+# 1. Copy examples and fill in real values
+cp values.yaml.example values.yaml
+cp vmagent.yaml.example vmagent.yaml
+cp targets/gpu-nodes.json.example targets/gpu-nodes.json
+
+# 2. Edit with your actual infrastructure details
+vim values.yaml
+
+# 3. Deploy
+helmfile -e corp sync
+```

--- a/environments/corp.example/targets/gpu-nodes.json.example
+++ b/environments/corp.example/targets/gpu-nodes.json.example
@@ -1,0 +1,25 @@
+[
+  {
+    "targets": [
+      "gpu-node-01:9400",
+      "gpu-node-02:9400",
+      "gpu-node-03:9400"
+    ],
+    "labels": {
+      "env": "baremetal",
+      "cluster": "YOUR_CLUSTER_NAME",
+      "workload_type": "training"
+    }
+  },
+  {
+    "targets": [
+      "infer-node-01:9400",
+      "infer-node-02:9400"
+    ],
+    "labels": {
+      "env": "baremetal",
+      "cluster": "YOUR_CLUSTER_NAME",
+      "workload_type": "inference"
+    }
+  }
+]

--- a/environments/corp.example/values.yaml.example
+++ b/environments/corp.example/values.yaml.example
@@ -1,0 +1,25 @@
+# Corp environment values template.
+# Copy to environments/corp/values.yaml (in the separate private repo)
+# and fill in real infrastructure details.
+
+image_registry: "YOUR_INTERNAL_REGISTRY_HERE"   # e.g. registry.internal.corp.com
+image_tag: "v1.0.0"
+
+# Airgap: path to pre-downloaded Helm chart .tgz files
+charts_dir: "/opt/gpu-mon/charts"
+
+# Feature flags
+metadata_collector:
+  enabled: true          # Enable S2 + VMware metadata collection
+
+mock_dcgm:
+  enabled: false         # Use real DCGM exporters in production
+
+# Grafana
+grafana_host: "grafana.monitoring.YOUR_DOMAIN_HERE"
+
+# Retention (adjust based on available storage)
+retention:
+  metrics_days: 90
+  logs_days: 30
+  metadata_days: 180

--- a/environments/corp.example/vmagent.yaml.example
+++ b/environments/corp.example/vmagent.yaml.example
@@ -1,0 +1,60 @@
+# Central vmagent configuration — production corp template.
+# Pulls metrics from all 120+ baremetal/VM GPU nodes via File SD.
+
+replicaCount: 2   # HA pair
+
+remoteWrite:
+  - url: "http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
+
+scrapeConfig:
+  global:
+    scrape_interval: 15s
+
+  scrape_configs:
+    # ── Baremetal GPU Clusters (File SD — Ansible-managed) ────────────────
+    - job_name: "baremetal-dcgm"
+      file_sd_configs:
+        - files: ["/etc/vmagent/sd/gpu-nodes.json"]
+          refresh_interval: 60s
+      relabel_configs:
+        - source_labels: [__address__]
+          regex: "(.+):.*"
+          target_label: node
+
+    - job_name: "baremetal-node-exporter"
+      file_sd_configs:
+        - files: ["/etc/vmagent/sd/gpu-nodes.json"]
+          refresh_interval: 60s
+      relabel_configs:
+        - source_labels: [__address__]
+          regex: "(.+):[0-9]+"
+          replacement: "${1}:9100"
+          target_label: __address__
+        - source_labels: [__address__]
+          regex: "(.+):.*"
+          target_label: node
+
+    # ── GPU VMs (VMware — File SD) ─────────────────────────────────────────
+    - job_name: "vm-dcgm"
+      file_sd_configs:
+        - files: ["/etc/vmagent/sd/vm-gpu-nodes.json"]
+          refresh_interval: 60s
+
+    # ── Inference servers ──────────────────────────────────────────────────
+    - job_name: "inference-servers"
+      file_sd_configs:
+        - files: ["/etc/vmagent/sd/inference-servers.json"]
+          refresh_interval: 60s
+      relabel_configs:
+        - source_labels: [__address__]
+          regex: "(.+):.*"
+          target_label: node
+
+    # ── K8s components ─────────────────────────────────────────────────────
+    - job_name: "kube-state-metrics"
+      kubernetes_sd_configs:
+        - role: service
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+          regex: "kube-state-metrics"
+          action: keep

--- a/environments/defaults.yaml
+++ b/environments/defaults.yaml
@@ -1,0 +1,34 @@
+# Common defaults shared across all environments.
+# Environment-specific files override these values.
+
+image_registry: ghcr.io/yoonsungnam/gpu-mon
+image_tag: latest
+
+# Set to true in corp/airgap environments
+charts_dir: ""
+
+# Feature flags
+metadata_collector:
+  enabled: false
+
+mock_dcgm:
+  enabled: false
+
+# Monitoring namespace
+namespace: monitoring
+
+# VictoriaMetrics remote write endpoint (within cluster)
+vminsert_url: "http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
+
+# ClickHouse connection
+clickhouse:
+  host: clickhouse.clickhouse.svc
+  port: 9000
+  database: gpu_monitoring
+  username: default
+
+# Retention
+retention:
+  metrics_days: 90       # VictoriaMetrics data retention
+  logs_days: 30          # ClickHouse gpu_unified_logs TTL
+  metadata_days: 180     # ClickHouse s2_jobs TTL

--- a/environments/homelab/clickhouse.yaml
+++ b/environments/homelab/clickhouse.yaml
@@ -1,0 +1,19 @@
+# ClickHouse cluster values — homelab overrides
+
+clickhouse:
+  cluster:
+    name: gpu-monitoring
+    layout:
+      shardsCount: 1
+      replicasCount: 1
+  storage:
+    size: 20Gi
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+
+# Schema initialization runs as an init job
+schema_init:
+  enabled: true
+  schemas_path: /schemas

--- a/environments/homelab/grafana.yaml
+++ b/environments/homelab/grafana.yaml
@@ -1,0 +1,45 @@
+# Grafana Helm values — homelab overrides
+
+grafana:
+  adminPassword: admin  # Change in production
+
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: VictoriaMetrics
+          type: prometheus
+          url: http://vmselect-victoriametrics.monitoring.svc:8481/select/0/prometheus
+          isDefault: true
+          access: proxy
+
+        - name: ClickHouse
+          type: grafana-clickhouse-datasource
+          url: http://clickhouse.clickhouse.svc:8123
+          jsonData:
+            host: clickhouse.clickhouse.svc
+            port: 8123
+            defaultDatabase: gpu_monitoring
+
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: gpu-mon
+          orgId: 1
+          folder: GPU Monitoring
+          type: file
+          disableDeletion: false
+          options:
+            path: /var/lib/grafana/dashboards/gpu-mon
+
+  dashboardsConfigMaps:
+    gpu-mon: grafana-dashboards
+
+  plugins:
+    - grafana-clickhouse-datasource
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi

--- a/environments/homelab/targets/gpu-nodes.json
+++ b/environments/homelab/targets/gpu-nodes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "targets": [
+      "mock-dcgm-exporter.monitoring.svc:9400"
+    ],
+    "labels": {
+      "env": "homelab",
+      "cluster": "homelab-cluster",
+      "workload_type": "training"
+    }
+  }
+]

--- a/environments/homelab/targets/inference-servers.json
+++ b/environments/homelab/targets/inference-servers.json
@@ -1,0 +1,10 @@
+[
+  {
+    "targets": [],
+    "labels": {
+      "env": "homelab",
+      "cluster": "homelab-cluster",
+      "workload_type": "inference"
+    }
+  }
+]

--- a/environments/homelab/values.yaml
+++ b/environments/homelab/values.yaml
@@ -1,0 +1,20 @@
+# homelab environment — K8s (e.g., k3s on dedicated nodes)
+# Deploy with: make homelab-sync
+#
+# Uses mock DCGM exporter to simulate GPU metrics.
+# No metadata collector (no S2 / VMware in homelab).
+
+image_registry: ghcr.io/yoonsungnam/gpu-mon
+image_tag: latest
+
+mock_dcgm:
+  enabled: true
+  node_count: 2
+  gpus_per_node: 2
+  gpu_model: A100
+
+metadata_collector:
+  enabled: false
+
+# Ingress / access
+grafana_host: grafana.homelab.local

--- a/environments/homelab/vector.yaml
+++ b/environments/homelab/vector.yaml
@@ -1,0 +1,45 @@
+# Vector Aggregator Helm values — homelab overrides
+# Receives logs from node Vector Agents, normalizes them, sinks to ClickHouse.
+
+role: Aggregator
+
+customConfig:
+  data_dir: /vector-data-dir
+
+  sources:
+    vector_agent_in:
+      type: vector
+      address: "0.0.0.0:6000"
+
+  transforms:
+    standardize:
+      type: remap
+      inputs: ["vector_agent_in"]
+      source: |
+        # Normalize to gpu_unified_logs schema
+        .log_level = upcase(string!(.level ?? "INFO"))
+        .source    = string!(.source ?? "system")
+        .metadata  = encode_json(.metadata ?? {})
+
+  sinks:
+    clickhouse_logs:
+      type: clickhouse
+      inputs: ["standardize"]
+      endpoint: "http://clickhouse.clickhouse.svc:8123"
+      database: gpu_monitoring
+      table: gpu_unified_logs
+      compression: gzip
+      batch:
+        max_bytes: 10485760
+        timeout_secs: 10
+
+service:
+  ports:
+    - name: vector
+      port: 6000
+      protocol: TCP
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi

--- a/environments/homelab/victoriametrics.yaml
+++ b/environments/homelab/victoriametrics.yaml
@@ -1,0 +1,26 @@
+# VictoriaMetrics Helm values — homelab overrides
+
+vminsert:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+vmselect:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+vmstorage:
+  replicaCount: 1
+  persistentVolume:
+    enabled: true
+    size: 20Gi
+  retentionPeriod: "30d"
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi

--- a/environments/homelab/vmagent.yaml
+++ b/environments/homelab/vmagent.yaml
@@ -1,0 +1,64 @@
+# Central vmagent Helm values — homelab overrides
+# Pulls metrics from all exporters and remote_writes to VictoriaMetrics.
+
+replicaCount: 1
+
+remoteWrite:
+  - url: "http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
+
+# Scrape configuration
+scrapeConfig:
+  global:
+    scrape_interval: 15s
+    evaluation_interval: 15s
+
+  scrape_configs:
+    # ── Mock DCGM Exporter (homelab) ──────────────────────────────────────
+    - job_name: "mock-dcgm"
+      static_configs:
+        - targets:
+            - "mock-dcgm-exporter.monitoring.svc:9400"
+          labels:
+            env: homelab
+            cluster: homelab-cluster
+            workload_type: training
+
+    # ── node-exporter (K8s DaemonSet) ─────────────────────────────────────
+    - job_name: "node-exporter"
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names: ["monitoring"]
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+          regex: "node-exporter"
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: node
+
+    # ── kube-state-metrics ────────────────────────────────────────────────
+    - job_name: "kube-state-metrics"
+      kubernetes_sd_configs:
+        - role: service
+          namespaces:
+            names: ["monitoring"]
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+          regex: "kube-state-metrics"
+          action: keep
+
+    # ── File SD: Baremetal GPU nodes (Ansible-managed) ────────────────────
+    # Used in corp/homelab when baremetal nodes exist.
+    # Empty in homelab (mock exporter handles this role).
+    # - job_name: "baremetal-dcgm"
+    #   file_sd_configs:
+    #     - files: ["/etc/vmagent/sd/gpu-nodes.json"]
+    #       refresh_interval: 60s
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,0 +1,113 @@
+---
+# gpu-mon Helmfile
+# Environments: macbook (Docker Compose only), homelab, corp
+#
+# Usage:
+#   helmfile -e homelab diff
+#   helmfile -e homelab sync
+#   helmfile -e corp sync  (requires gpu-mon-corp symlink)
+
+environments:
+  homelab:
+    values:
+      - environments/defaults.yaml
+      - environments/homelab/values.yaml
+  corp:
+    values:
+      - environments/defaults.yaml
+      - environments/corp/values.yaml  # symlinked from gpu-mon-corp
+
+---
+
+# Helm repositories (skipped in corp airgap mode; charts come from local .tgz)
+repositories:
+  {{ if ne .Environment.Name "corp" }}
+  - name: victoriametrics
+    url: https://victoriametrics.github.io/helm-charts
+  - name: grafana
+    url: https://grafana.github.io/helm-charts
+  - name: vector
+    url: https://helm.vector.dev
+  - name: clickhouse-operator
+    url: https://docs.altinity.com/clickhouse-operator
+  {{ end }}
+
+---
+
+releases:
+  # ─── VictoriaMetrics Cluster ──────────────────────────────────────────────
+  - name: victoriametrics
+    namespace: monitoring
+    {{ if eq .Environment.Name "corp" }}
+    chart: "{{ .Values.charts_dir }}/victoria-metrics-cluster-0.14.17.tgz"
+    {{ else }}
+    chart: victoriametrics/victoria-metrics-cluster
+    version: "0.14.17"
+    {{ end }}
+    values:
+      - environments/{{ .Environment.Name }}/victoriametrics.yaml
+
+  # ─── Central vmagent ──────────────────────────────────────────────────────
+  - name: vmagent-central
+    namespace: monitoring
+    chart: charts/vmagent-central
+    values:
+      - environments/{{ .Environment.Name }}/vmagent.yaml
+
+  # ─── ClickHouse Operator ──────────────────────────────────────────────────
+  - name: clickhouse-operator
+    namespace: clickhouse
+    {{ if eq .Environment.Name "corp" }}
+    chart: "{{ .Values.charts_dir }}/altinity-clickhouse-operator-0.24.0.tgz"
+    {{ else }}
+    chart: clickhouse-operator/altinity-clickhouse-operator
+    version: "0.24.0"
+    {{ end }}
+
+  # ─── ClickHouse Cluster ───────────────────────────────────────────────────
+  - name: clickhouse
+    namespace: clickhouse
+    chart: charts/clickhouse-cluster
+    needs:
+      - clickhouse/clickhouse-operator
+    values:
+      - environments/{{ .Environment.Name }}/clickhouse.yaml
+
+  # ─── Grafana ──────────────────────────────────────────────────────────────
+  - name: grafana
+    namespace: monitoring
+    {{ if eq .Environment.Name "corp" }}
+    chart: "{{ .Values.charts_dir }}/grafana-8.8.2.tgz"
+    {{ else }}
+    chart: grafana/grafana
+    version: "8.8.2"
+    {{ end }}
+    values:
+      - environments/{{ .Environment.Name }}/grafana.yaml
+
+  # ─── Vector Aggregator ────────────────────────────────────────────────────
+  - name: vector
+    namespace: monitoring
+    {{ if eq .Environment.Name "corp" }}
+    chart: "{{ .Values.charts_dir }}/vector-0.36.1.tgz"
+    {{ else }}
+    chart: vector/vector
+    version: "0.36.1"
+    {{ end }}
+    values:
+      - environments/{{ .Environment.Name }}/vector.yaml
+
+  # ─── Metadata Collector ───────────────────────────────────────────────────
+  - name: metadata-collector
+    namespace: monitoring
+    chart: charts/metadata-collector
+    values:
+      - environments/{{ .Environment.Name }}/metadata-collector.yaml
+    # Only deploy in corp; homelab uses mock data
+    condition: metadata_collector.enabled
+
+  # ─── Mock DCGM Exporter (homelab only) ───────────────────────────────────
+  - name: mock-dcgm-exporter
+    namespace: monitoring
+    chart: charts/mock-dcgm-exporter
+    condition: mock_dcgm.enabled


### PR DESCRIPTION
## Summary
- `helmfile.yaml`: multi-env release orchestration (homelab/corp)
- `environments/defaults.yaml`: shared defaults
- `environments/homelab/`: K8s values for all components
- `environments/corp.example/`: private config template

Split from #1 — PR 8/10

## Test plan
- [ ] `helmfile -e homelab lint` passes
- [ ] `helmfile -e homelab diff` renders without errors
- [ ] Corp example files contain only placeholders