### PR TITLE
feat: add alerting rules and Ansible node agent deployment

### DIFF
--- a/alerting/alertmanager/homelab.yaml
+++ b/alerting/alertmanager/homelab.yaml
@@ -1,0 +1,18 @@
+# Alertmanager configuration — homelab environment
+# Routes all alerts to a local webhook receiver for testing.
+
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: [alertname, node]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: homelab-default
+
+receivers:
+  - name: homelab-default
+    webhook_configs:
+      - url: http://localhost:9093/alerts
+        send_resolved: true

--- a/alerting/rules/gpu-efficiency.yaml
+++ b/alerting/rules/gpu-efficiency.yaml
@@ -1,0 +1,40 @@
+groups:
+  - name: gpu-efficiency
+    interval: 300s
+    rules:
+      # ── Low utilization ───────────────────────────────────────────────────
+      - alert: GPULowUtilization
+        expr: |
+          avg_over_time(DCGM_FI_DEV_GPU_UTIL[30m]) < 10
+          and on(node, gpu)
+          avg_over_time(DCGM_FI_DEV_FB_USED[30m]) > 1000
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GPU underutilized on {{ $labels.node }} GPU {{ $labels.gpu }}"
+          description: "Average GPU utilization is {{ $value }}% over 30m while memory is in use. Possible idle job."
+
+      # ── Low Tensor Core utilization during training ───────────────────────
+      - alert: GPUTensorCoreUnderutilized
+        expr: |
+          DCGM_FI_PROF_PIPE_TENSOR_ACTIVE < 0.20
+          and DCGM_FI_DEV_GPU_UTIL > 80
+          and on(node) label_replace(up{workload_type="training"}, "node", "$1", "instance", "(.+):.*") == 1
+        for: 15m
+        labels:
+          severity: info
+        annotations:
+          summary: "Low Tensor Core usage on {{ $labels.node }} GPU {{ $labels.gpu }} (training)"
+          description: "Tensor Core active: {{ $value | humanizePercentage }}. GPU Util is high but Tensor Cores are idle — possible memory-bound or compute-unoptimized workload."
+
+      # ── Memory pressure ───────────────────────────────────────────────────
+      - alert: GPUMemoryPressure
+        expr: |
+          (DCGM_FI_DEV_FB_USED / (DCGM_FI_DEV_FB_USED + DCGM_FI_DEV_FB_FREE)) > 0.95
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GPU memory nearly full on {{ $labels.node }} GPU {{ $labels.gpu }}"
+          description: "{{ $value | humanizePercentage }} of GPU memory is used."

--- a/alerting/rules/gpu-hardware.yaml
+++ b/alerting/rules/gpu-hardware.yaml
@@ -1,0 +1,51 @@
+groups:
+  - name: gpu-hardware
+    interval: 60s
+    rules:
+      # ── Temperature ──────────────────────────────────────────────────────
+      - alert: GPUTemperatureHigh
+        expr: DCGM_FI_DEV_GPU_TEMP > 85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GPU temperature high on {{ $labels.node }} GPU {{ $labels.gpu }}"
+          description: "Temperature is {{ $value }}°C (threshold: 85°C)."
+
+      - alert: GPUTemperatureCritical
+        expr: DCGM_FI_DEV_GPU_TEMP > 95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "GPU temperature critical on {{ $labels.node }} GPU {{ $labels.gpu }}"
+          description: "Temperature is {{ $value }}°C. Possible throttling or hardware failure."
+
+      # ── XID Errors ───────────────────────────────────────────────────────
+      - alert: GPUXidError
+        expr: increase(DCGM_FI_DEV_XID_ERRORS[5m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "XID error detected on {{ $labels.node }} GPU {{ $labels.gpu }}"
+          description: "{{ $value }} XID error(s) in the last 5 minutes. Possible hardware failure."
+
+      # ── Power ─────────────────────────────────────────────────────────────
+      - alert: GPUPowerHigh
+        expr: DCGM_FI_DEV_POWER_USAGE > 400
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GPU power usage high on {{ $labels.node }} GPU {{ $labels.gpu }}"
+          description: "Power is {{ $value }}W."
+
+      # ── SM Clock throttle ─────────────────────────────────────────────────
+      - alert: GPUClockThrottle
+        expr: DCGM_FI_DEV_SM_CLOCK < 500 and DCGM_FI_DEV_GPU_UTIL > 50
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GPU clock throttled on {{ $labels.node }} GPU {{ $labels.gpu }}"
+          description: "SM Clock: {{ $value }}MHz while utilization is high. Check temperature and power."

--- a/ansible/inventory/homelab.ini
+++ b/ansible/inventory/homelab.ini
@@ -1,0 +1,12 @@
+# Homelab Ansible inventory
+# Add your homelab GPU nodes here.
+
+[gpu_nodes]
+# homelab-gpu-01 ansible_host=192.168.1.101 ansible_user=ubuntu
+# homelab-gpu-02 ansible_host=192.168.1.102 ansible_user=ubuntu
+
+[inference_servers]
+# homelab-infer-01 ansible_host=192.168.1.201 ansible_user=ubuntu
+
+[all:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/ansible/playbooks/deploy-node-agents.yaml
+++ b/ansible/playbooks/deploy-node-agents.yaml
@@ -1,0 +1,27 @@
+---
+# Deploy node-level agents (DCGM Exporter + Vector Agent) to GPU nodes.
+# Works for both Baremetal and VM environments.
+#
+# Usage:
+#   ansible-playbook -i inventory/homelab.ini playbooks/deploy-node-agents.yaml
+#   ansible-playbook -i inventory/corp.ini playbooks/deploy-node-agents.yaml  # (symlinked)
+
+- name: Deploy GPU monitoring node agents
+  hosts: gpu_nodes
+  become: true
+  vars:
+    dcgm_version: "3.3.8-3.6.0-ubuntu22.04"
+    vector_version: "0.42.0"
+    vector_aggregator_host: "{{ hostvars['k8s-control']['ansible_host'] | default('vector-aggregator.monitoring.svc') }}"
+    vector_aggregator_port: 6000
+
+  roles:
+    - dcgm-exporter
+    - vector-agent
+    - node-exporter
+
+  post_tasks:
+    - name: Update File SD target list in ConfigMap
+      delegate_to: localhost
+      run_once: true
+      include_tasks: tasks/update-file-sd.yaml

--- a/ansible/roles/dcgm-exporter/tasks/main.yaml
+++ b/ansible/roles/dcgm-exporter/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- name: Create DCGM Exporter systemd service
+  template:
+    src: dcgm-exporter.service.j2
+    dest: /etc/systemd/system/dcgm-exporter.service
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable and start DCGM Exporter
+  systemd:
+    name: dcgm-exporter
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/ansible/roles/dcgm-exporter/templates/dcgm-exporter.service.j2
+++ b/ansible/roles/dcgm-exporter/templates/dcgm-exporter.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=NVIDIA DCGM Exporter
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/dcgm-exporter \
+  --address=:9400 \
+  --collectors=/etc/dcgm-exporter/counters.csv
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/vector-agent/tasks/main.yaml
+++ b/ansible/roles/vector-agent/tasks/main.yaml
@@ -1,0 +1,33 @@
+---
+- name: Install Vector agent
+  get_url:
+    url: "https://packages.timber.io/vector/{{ vector_version }}/vector-{{ vector_version }}-x86_64-unknown-linux-musl.tar.gz"
+    dest: /tmp/vector.tar.gz
+
+- name: Extract Vector binary
+  unarchive:
+    src: /tmp/vector.tar.gz
+    dest: /usr/local/bin/
+    remote_src: true
+    extra_opts: ["--strip-components=2", "--wildcards", "*/bin/vector"]
+
+- name: Deploy Vector agent config
+  template:
+    src: vector-agent.toml.j2
+    dest: /etc/vector/vector.toml
+    mode: "0644"
+  notify: Restart Vector
+
+- name: Create Vector systemd service
+  template:
+    src: vector.service.j2
+    dest: /etc/systemd/system/vector.service
+    mode: "0644"
+  notify: Reload systemd
+
+- name: Enable and start Vector
+  systemd:
+    name: vector
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/ansible/roles/vector-agent/templates/vector-agent.toml.j2
+++ b/ansible/roles/vector-agent/templates/vector-agent.toml.j2
@@ -1,0 +1,23 @@
+# Vector Agent — lightweight log forwarder (no parsing here, offloaded to aggregator)
+
+[sources.syslog]
+type = "journald"
+include_units = ["dcgm-exporter.service", "kubelet.service", "containerd.service"]
+
+[sources.gpu_driver_logs]
+type = "file"
+include = ["/var/log/nvidia-*.log", "/var/log/Xorg.*.log"]
+
+[transforms.add_metadata]
+type = "remap"
+inputs = ["syslog", "gpu_driver_logs"]
+source = '''
+  .node_id  = get_hostname!()
+  .env      = "{{ env | default('baremetal') }}"
+  .cluster_id = "{{ cluster_id | default('default') }}"
+'''
+
+[sinks.aggregator]
+type = "vector"
+inputs = ["add_metadata"]
+address = "{{ vector_aggregator_host }}:{{ vector_aggregator_port }}"


### PR DESCRIPTION
## Summary
- `alerting/`: vmalert rules (GPU hardware + efficiency) and Alertmanager config
- `ansible/`: node agent deployment playbook with dcgm-exporter and vector-agent roles

Split from #1 — PR 9/10

## Test plan
- [ ] Alert rule YAML is valid (yamllint)
- [ ] PromQL expressions are syntactically valid
- [ ] Ansible playbook syntax check passes