### PR TITLE
ci: skip Docker integration tests on docs-only changes

### DIFF
--- a/.github/workflows/component-e2e-tests.yml
+++ b/.github/workflows/component-e2e-tests.yml
@@ -36,7 +36,7 @@ jobs:
               - 'environments/**'
               - 'tests/**'
               - 'scripts/**'
-              - 'helmfile.yaml.gotmpl'
+              - 'helmfile.yaml'
               - 'pyproject.toml'
               - 'Makefile'
               - '.github/workflows/component-e2e-tests.yml'


### PR DESCRIPTION
## Summary
- Add path-based change detection to the Docker Integration Tests workflow using `dorny/paths-filter`
- When a PR only touches non-runtime files (e.g., `docs/`, `README.md`, `CLAUDE.md`), the `Component Tests` and `E2E Tests` jobs skip instantly with success instead of spinning up the full Docker Compose stack (~10 min)
- Skip jobs use the **same job name** as the real jobs, so branch protection required checks still pass

### Runtime paths that trigger full tests
`src/`, `charts/`, `compose/`, `schemas/`, `environments/`, `tests/`, `scripts/`, `helmfile.yaml.gotmpl`, `pyproject.toml`, `Makefile`, `.github/workflows/component-e2e-tests.yml`

### Paths that skip (docs-only)
Everything else — `docs/`, `README.md`, `CLAUDE.md`, `AGENTS.md`, `.codex/`, etc.

## Test plan
- [ ] PR touching only `docs/` skips Docker tests and merges without waiting
- [ ] PR touching `src/` or `compose/` still runs full Docker integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)