### PR TITLE
docs: expand taxonomy plan with platform taxonomy

### DIFF
--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -13,12 +13,24 @@ for the gpu-mon project.
 - **File SD file 1:1 Ansible group** — each file is generated from exactly one Ansible group
 - **Names follow scrape role**, not workload type
 - **`platform` label describes infrastructure**, not deployment environment
+- **Deployment environment remains explicit** via a separate `deployment_env` label
 
 ## Platform Taxonomy
 
 The `platform` label describes the infrastructure platform where the monitored target runs.
 The `environments/` directory structure is orthogonal — it describes *where the stack is deployed*
 (macbook, homelab, corp), not the platform of the monitored nodes.
+
+## Deployment Environment Taxonomy
+
+Use `deployment_env` to preserve the stack/environment context that `env` currently carries in
+homelab/macbook configs and tests.
+
+| `deployment_env` value | Meaning |
+|---|---|
+| `corp` | Corporate deployment environment |
+| `homelab` | Homelab K8s deployment environment |
+| `macbook` | Local Docker Compose development environment |
 
 | `platform` value | Meaning | Environments |
 |---|---|---|
@@ -45,7 +57,8 @@ Examples:
 
 | Before | After | Reason |
 |---|---|---|
-| `env` | `platform` | `env` reads as prod/staging; actual values describe infrastructure platform |
+| `env` | `deployment_env` | Preserve deployment environment context explicitly |
+| add new label | `platform` | Split infrastructure type from deployment environment |
 | `server_type` | `serving_runtime` | vllm/triton are serving runtimes, not server types |
 
 ## vmagent Job Mapping
@@ -59,29 +72,30 @@ Examples:
 
 ### corp (via corp.example/ templates)
 - Rename `gpu-nodes.json` → `baremetal-gpu-nodes.json`
-- Labels: `env` → `platform` (values: `baremetal`, `vm`)
+- Labels: add `deployment_env: corp`; set `platform` to `baremetal` or `vm`
 - Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]`
 
 ### homelab
 - Keep `targets/gpu-nodes.json` as a K8s mock-exporter target file; do not rename it to `baremetal-gpu-nodes.json`
-- Labels: `"env": "homelab"` → `"platform": "k8s"` (mock exporter runs as K8s pod)
-- vmagent static_configs: `env: homelab` → `platform: k8s`
+- Labels: `"env": "homelab"` → `"deployment_env": "homelab"`; add `"platform": "k8s"` (mock exporter runs as K8s pod)
+- vmagent static_configs: `env: homelab` → `deployment_env: homelab`; add `platform: k8s`
 - Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]` (empty by default; ready for physical GPU nodes or cloud GPU/TPU VMs added to the homelab)
 - Commented-out File SD path: update to `baremetal-gpu-nodes.json`
 
 ### macbook
 - No File SD files (Docker Compose, no vmagent File SD)
+- Keep `deployment_env: macbook`
 - If/when mock exporter emits a platform label, use `docker`
 
 ### Shared
-- Vector agent template: `.env` → `.platform`
-- ClickHouse schema: `env` column → `platform` column (requires migration if table exists)
+- Vector agent template: `.env` → `.deployment_env`, and add `.platform`
+- ClickHouse schema: `env` column → `deployment_env` column; add `platform` column (requires migration if table exists)
 
 ## Cross-Repo Sync Checklist
 
 - Corp repo File SD files, Ansible inventory, and vmagent config must follow this naming
 - `corp.example/` templates in the public repo must use the same naming
-- Grafana dashboards and alerting rules referencing `env` label must migrate to `platform`
+- Grafana dashboards and alerting rules referencing `env` label must migrate to `deployment_env`; infrastructure-level queries should use `platform`
 
 ## Validation
 

--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -23,13 +23,13 @@ The `environments/` directory structure is orthogonal — it describes *where th
 | `platform` value | Meaning | Environments |
 |---|---|---|
 | `baremetal` | Physical GPU nodes, Ansible-managed | corp |
-| `vm` | VMware VM GPU nodes, Ansible-managed | corp |
+| `vm` | GPU/TPU VMs (VMware, GCP, AWS, etc.), Ansible-managed | corp, homelab |
 | `k8s` | K8s-native workloads (real or mock pods) | corp, homelab |
 | `docker` | Docker Compose local stack | macbook |
 
 Examples:
 - Corp baremetal DCGM targets → `platform: "baremetal"`
-- Corp VMware VM DCGM targets → `platform: "vm"`
+- Corp or homelab GPU/TPU VM targets → `platform: "vm"`
 - Homelab mock DCGM exporter pod → `platform: "k8s"`
 - Macbook mock DCGM exporter container → `platform: "docker"`
 
@@ -38,7 +38,7 @@ Examples:
 | File SD File | Ansible Group | Port | Scrape Target |
 |---|---|---|---|
 | `baremetal-gpu-nodes.json` | `baremetal_gpu_nodes` | :9400 (+:9100 port rewrite) | Baremetal DCGM exporter + node-exporter |
-| `vm-gpu-nodes.json` | `vm_gpu_nodes` | :9400 | VMware VM DCGM exporter |
+| `vm-gpu-nodes.json` | `vm_gpu_nodes` | :9400 | GPU/TPU VM DCGM exporter |
 | `inference-servers.json` | `inference_servers` | :8080 | Inference app metrics |
 
 ## Label Renames

--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -63,7 +63,7 @@ Examples:
 - Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]`
 
 ### homelab
-- Rename `targets/gpu-nodes.json` → `targets/baremetal-gpu-nodes.json`
+- Keep `targets/gpu-nodes.json` as a K8s mock-exporter target file; do not rename it to `baremetal-gpu-nodes.json`
 - Labels: `"env": "homelab"` → `"platform": "k8s"` (mock exporter runs as K8s pod)
 - vmagent static_configs: `env: homelab` → `platform: k8s`
 - Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]` placeholder

--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -53,6 +53,9 @@ Examples:
 | `vm-gpu-nodes.json` | `vm_gpu_nodes` | :9400 | GPU VM DCGM exporter |
 | `inference-servers.json` | `inference_servers` | :8080 | Inference app metrics |
 
+Note: current naming and examples assume NVIDIA/DCGM-based GPU monitoring. AMD GPU support is not
+modeled in this taxonomy yet and should be considered explicitly in a follow-up design pass.
+
 ## Label Renames
 
 | Before | After | Reason |

--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -66,7 +66,7 @@ Examples:
 - Keep `targets/gpu-nodes.json` as a K8s mock-exporter target file; do not rename it to `baremetal-gpu-nodes.json`
 - Labels: `"env": "homelab"` → `"platform": "k8s"` (mock exporter runs as K8s pod)
 - vmagent static_configs: `env: homelab` → `platform: k8s`
-- Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]` placeholder
+- Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]` (both placeholder groups, no real hosts in homelab)
 - Commented-out File SD path: update to `baremetal-gpu-nodes.json`
 
 ### macbook

--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -66,7 +66,7 @@ Examples:
 - Keep `targets/gpu-nodes.json` as a K8s mock-exporter target file; do not rename it to `baremetal-gpu-nodes.json`
 - Labels: `"env": "homelab"` → `"platform": "k8s"` (mock exporter runs as K8s pod)
 - vmagent static_configs: `env: homelab` → `platform: k8s`
-- Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]` (both placeholder groups, no real hosts in homelab)
+- Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]` (empty by default; ready for physical GPU nodes or cloud GPU/TPU VMs added to the homelab)
 - Commented-out File SD path: update to `baremetal-gpu-nodes.json`
 
 ### macbook

--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -35,13 +35,13 @@ homelab/macbook configs and tests.
 | `platform` value | Meaning | Environments |
 |---|---|---|
 | `baremetal` | Physical GPU nodes, Ansible-managed | corp |
-| `vm` | GPU/TPU VMs (VMware, GCP, AWS, etc.), Ansible-managed | corp, homelab |
+| `vm` | GPU VMs (VMware, GCP, AWS, etc.), Ansible-managed | corp, homelab |
 | `k8s` | K8s-native workloads (real or mock pods) | corp, homelab |
 | `docker` | Docker Compose local stack | macbook |
 
 Examples:
 - Corp baremetal DCGM targets → `platform: "baremetal"`
-- Corp or homelab GPU/TPU VM targets → `platform: "vm"`
+- Corp or homelab GPU VM targets → `platform: "vm"`
 - Homelab mock DCGM exporter pod → `platform: "k8s"`
 - Macbook mock DCGM exporter container → `platform: "docker"`
 
@@ -50,7 +50,7 @@ Examples:
 | File SD File | Ansible Group | Port | Scrape Target |
 |---|---|---|---|
 | `baremetal-gpu-nodes.json` | `baremetal_gpu_nodes` | :9400 (+:9100 port rewrite) | Baremetal DCGM exporter + node-exporter |
-| `vm-gpu-nodes.json` | `vm_gpu_nodes` | :9400 | GPU/TPU VM DCGM exporter |
+| `vm-gpu-nodes.json` | `vm_gpu_nodes` | :9400 | GPU VM DCGM exporter |
 | `inference-servers.json` | `inference_servers` | :8080 | Inference app metrics |
 
 ## Label Renames

--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -35,13 +35,13 @@ homelab/macbook configs and tests.
 | `platform` value | Meaning | Environments |
 |---|---|---|
 | `baremetal` | Physical GPU nodes, Ansible-managed | corp |
-| `vm` | GPU VMs (VMware, GCP, AWS, etc.), Ansible-managed | corp, homelab |
+| `vm` | GPU/TPU VMs (VMware, GCP, AWS, etc.), Ansible-managed | corp, homelab |
 | `k8s` | K8s-native workloads (real or mock pods) | corp, homelab |
 | `docker` | Docker Compose local stack | macbook |
 
 Examples:
 - Corp baremetal DCGM targets → `platform: "baremetal"`
-- Corp or homelab GPU VM targets → `platform: "vm"`
+- Corp or homelab GPU/TPU VM targets → `platform: "vm"`
 - Homelab mock DCGM exporter pod → `platform: "k8s"`
 - Macbook mock DCGM exporter container → `platform: "docker"`
 

--- a/docs/taxonomy-redesign-plan.md
+++ b/docs/taxonomy-redesign-plan.md
@@ -12,8 +12,28 @@ for the gpu-mon project.
 - **Monitoring unit = host x port** — a single physical server may expose multiple exporters
 - **File SD file 1:1 Ansible group** — each file is generated from exactly one Ansible group
 - **Names follow scrape role**, not workload type
+- **`platform` label describes infrastructure**, not deployment environment
 
-## Naming Convention
+## Platform Taxonomy
+
+The `platform` label describes the infrastructure platform where the monitored target runs.
+The `environments/` directory structure is orthogonal — it describes *where the stack is deployed*
+(macbook, homelab, corp), not the platform of the monitored nodes.
+
+| `platform` value | Meaning | Environments |
+|---|---|---|
+| `baremetal` | Physical GPU nodes, Ansible-managed | corp |
+| `vm` | VMware VM GPU nodes, Ansible-managed | corp |
+| `k8s` | K8s-native workloads (real or mock pods) | corp, homelab |
+| `docker` | Docker Compose local stack | macbook |
+
+Examples:
+- Corp baremetal DCGM targets → `platform: "baremetal"`
+- Corp VMware VM DCGM targets → `platform: "vm"`
+- Homelab mock DCGM exporter pod → `platform: "k8s"`
+- Macbook mock DCGM exporter container → `platform: "docker"`
+
+## File SD Naming Convention
 
 | File SD File | Ansible Group | Port | Scrape Target |
 |---|---|---|---|
@@ -25,7 +45,7 @@ for the gpu-mon project.
 
 | Before | After | Reason |
 |---|---|---|
-| `env` | `platform` | `env` reads as prod/staging; actual values are baremetal/vmware |
+| `env` | `platform` | `env` reads as prod/staging; actual values describe infrastructure platform |
 | `server_type` | `serving_runtime` | vllm/triton are serving runtimes, not server types |
 
 ## vmagent Job Mapping
@@ -34,6 +54,28 @@ for the gpu-mon project.
 - **baremetal-node-exporter** job: scrapes same file with port-rewrite relabel to :9100
 - **vm-dcgm** job: scrapes `vm-gpu-nodes.json` on :9400
 - **k8s-inference-pods** job: uses `serving_runtime` label (renamed from `server_type`)
+
+## Changes Per Environment
+
+### corp (via corp.example/ templates)
+- Rename `gpu-nodes.json` → `baremetal-gpu-nodes.json`
+- Labels: `env` → `platform` (values: `baremetal`, `vm`)
+- Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]`
+
+### homelab
+- Rename `targets/gpu-nodes.json` → `targets/baremetal-gpu-nodes.json`
+- Labels: `"env": "homelab"` → `"platform": "k8s"` (mock exporter runs as K8s pod)
+- vmagent static_configs: `env: homelab` → `platform: k8s`
+- Ansible: `[gpu_nodes]` → `[baremetal_gpu_nodes]`, add `[vm_gpu_nodes]` placeholder
+- Commented-out File SD path: update to `baremetal-gpu-nodes.json`
+
+### macbook
+- No File SD files (Docker Compose, no vmagent File SD)
+- If/when mock exporter emits a platform label, use `docker`
+
+### Shared
+- Vector agent template: `.env` → `.platform`
+- ClickHouse schema: `env` column → `platform` column (requires migration if table exists)
 
 ## Cross-Repo Sync Checklist
 


### PR DESCRIPTION
## Summary

- Expand `docs/taxonomy-redesign-plan.md` (merged in PR #30) with platform taxonomy and per-environment change details
- Define four `platform` label values: `baremetal`, `vm`, `k8s`, `docker`
- Clarify that `environments/` directory (deployment target) is orthogonal to `platform` label (infrastructure type)
- Add per-environment change lists (corp, homelab, macbook, shared) to guide implementation PRs

## Context

During review of PR #30, three design questions surfaced:
1. `env` → `platform` rename vs `environments/` directory name — resolved: orthogonal concepts
2. Homelab runs on K8s, not baremetal — assigned `platform: "k8s"`
3. macbook is Docker Compose — assigned `platform: "docker"`

## Test plan

- [x] Docs-only change, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)