### PR TITLE
refactor: rename env → deployment_env + add platform label

### DIFF
--- a/ansible/roles/vector-agent/templates/vector-agent.toml.j2
+++ b/ansible/roles/vector-agent/templates/vector-agent.toml.j2
@@ -13,7 +13,8 @@ type = "remap"
 inputs = ["syslog", "gpu_driver_logs"]
 source = '''
   .node_id  = get_hostname!()
-  .env      = "{{ env | default('baremetal') }}"
+  .deployment_env = "{{ deployment_env | default('corp') }}"
+  .platform       = "{{ platform | default('baremetal') }}"
   .cluster_id = "{{ cluster_id | default('default') }}"
 '''
 

--- a/ansible/roles/vector-agent/templates/vector-agent.toml.j2
+++ b/ansible/roles/vector-agent/templates/vector-agent.toml.j2
@@ -13,8 +13,8 @@ type = "remap"
 inputs = ["syslog", "gpu_driver_logs"]
 source = '''
   .node_id  = get_hostname!()
-  .deployment_env = "{{ deployment_env | default('corp') }}"
-  .platform       = "{{ platform | default('baremetal') }}"
+  .deployment_env = "{{ deployment_env }}"
+  .platform       = "{{ platform }}"
   .cluster_id = "{{ cluster_id | default('default') }}"
 '''
 

--- a/compose/clickhouse-init/00-gpu-monitoring.sql
+++ b/compose/clickhouse-init/00-gpu-monitoring.sql
@@ -3,7 +3,8 @@ CREATE DATABASE IF NOT EXISTS gpu_monitoring;
 CREATE TABLE IF NOT EXISTS gpu_monitoring.gpu_unified_logs
 (
     timestamp   DateTime64(3)          CODEC(Delta, ZSTD),
-    env         LowCardinality(String),
+    deployment_env LowCardinality(String),
+    platform       LowCardinality(String),
     cluster_id  LowCardinality(String),
     node_id     String,
     gpu_id      Nullable(UInt8),
@@ -14,7 +15,7 @@ CREATE TABLE IF NOT EXISTS gpu_monitoring.gpu_unified_logs
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(timestamp)
-ORDER BY (env, cluster_id, node_id, timestamp)
+ORDER BY (deployment_env, platform, cluster_id, node_id, timestamp)
 TTL toDateTime(timestamp) + INTERVAL 30 DAY
 SETTINGS index_granularity = 8192;
 

--- a/compose/vmagent-config.yaml
+++ b/compose/vmagent-config.yaml
@@ -7,6 +7,7 @@ scrape_configs:
       - targets:
           - "mock-dcgm-exporter:9400"
         labels:
-          env: homelab
+          deployment_env: macbook
+          platform: docker
           cluster: macbook
           workload_type: training

--- a/environments/corp.example/targets/gpu-nodes.json.example
+++ b/environments/corp.example/targets/gpu-nodes.json.example
@@ -6,7 +6,8 @@
       "gpu-node-03:9400"
     ],
     "labels": {
-      "env": "baremetal",
+      "deployment_env": "corp",
+      "platform": "baremetal",
       "cluster": "YOUR_CLUSTER_NAME",
       "workload_type": "training"
     }
@@ -17,7 +18,8 @@
       "infer-node-02:9400"
     ],
     "labels": {
-      "env": "baremetal",
+      "deployment_env": "corp",
+      "platform": "baremetal",
       "cluster": "YOUR_CLUSTER_NAME",
       "workload_type": "inference"
     }

--- a/environments/homelab/targets/gpu-nodes.json
+++ b/environments/homelab/targets/gpu-nodes.json
@@ -4,7 +4,8 @@
       "mock-dcgm-exporter.monitoring.svc:9400"
     ],
     "labels": {
-      "env": "homelab",
+      "deployment_env": "homelab",
+      "platform": "k8s",
       "cluster": "homelab-cluster",
       "workload_type": "training"
     }

--- a/environments/homelab/targets/inference-servers.json
+++ b/environments/homelab/targets/inference-servers.json
@@ -2,7 +2,8 @@
   {
     "targets": [],
     "labels": {
-      "env": "homelab",
+      "deployment_env": "homelab",
+      "platform": "k8s",
       "cluster": "homelab-cluster",
       "workload_type": "inference"
     }

--- a/environments/homelab/vmagent.yaml
+++ b/environments/homelab/vmagent.yaml
@@ -18,7 +18,8 @@ scrapeConfig:
         - targets:
             - "mock-dcgm-exporter.monitoring.svc:9400"
           labels:
-            env: homelab
+            deployment_env: homelab
+            platform: k8s
             cluster: homelab-cluster
             workload_type: training
 

--- a/schemas/gpu_unified_logs.sql
+++ b/schemas/gpu_unified_logs.sql
@@ -7,7 +7,8 @@ CREATE DATABASE IF NOT EXISTS gpu_monitoring ON CLUSTER '{cluster}';
 CREATE TABLE IF NOT EXISTS gpu_monitoring.gpu_unified_logs ON CLUSTER '{cluster}'
 (
     timestamp   DateTime64(3)                    CODEC(Delta, ZSTD),
-    env         LowCardinality(String),           -- baremetal, k8s, vm, homelab
+    deployment_env LowCardinality(String),          -- macbook, homelab, corp
+    platform       LowCardinality(String),          -- docker, k8s, baremetal, vm
     cluster_id  LowCardinality(String),
     node_id     String,
     gpu_id      Nullable(UInt8),
@@ -18,6 +19,6 @@ CREATE TABLE IF NOT EXISTS gpu_monitoring.gpu_unified_logs ON CLUSTER '{cluster}
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(timestamp)
-ORDER BY (env, cluster_id, node_id, timestamp)
+ORDER BY (deployment_env, platform, cluster_id, node_id, timestamp)
 TTL toDateTime(timestamp) + INTERVAL 30 DAY
 SETTINGS index_granularity = 8192;

--- a/src/mock-dcgm-exporter/main.py
+++ b/src/mock-dcgm-exporter/main.py
@@ -37,7 +37,7 @@ _metrics_lock = threading.Lock()
 
 def _gpu_label(node_idx: int, gpu_idx: int) -> str:
     node_name = f"mock-node-{node_idx:02d}"
-    return f'node="{node_name}",gpu="{gpu_idx}",gpu_model="{GPU_MODEL}",env="homelab"'
+    return f'node="{node_name}",gpu="{gpu_idx}",gpu_model="{GPU_MODEL}",deployment_env="macbook",platform="docker"'
 
 
 def _simulate_util(t: float, node: int, gpu: int) -> float:

--- a/src/mock-dcgm-exporter/tests/test_metrics.py
+++ b/src/mock-dcgm-exporter/tests/test_metrics.py
@@ -4,7 +4,7 @@ Unit tests for mock-dcgm-exporter metric generation.
 Validates:
 - All expected L1 and L2 DCGM metric names are present
 - Correct number of series (NODE_COUNT × GPUS_PER_NODE)
-- Required labels on every metric (node, gpu, gpu_model, env)
+- Required labels on every metric (node, gpu, gpu_model, deployment_env, platform)
 - Value ranges are physically plausible
 """
 
@@ -39,7 +39,7 @@ L2_METRICS = [
     "DCGM_FI_PROF_NVLINK_TX_BYTES",
 ]
 
-REQUIRED_LABELS = ["node", "gpu", "gpu_model", "env"]
+REQUIRED_LABELS = ["node", "gpu", "gpu_model", "deployment_env", "platform"]
 
 # Use small topology for deterministic tests
 NODE_COUNT    = 2
@@ -145,9 +145,15 @@ def test_gpu_label_is_numeric(parsed_series):
 
 
 @pytest.mark.unit
-def test_env_label_is_homelab(parsed_series):
+def test_deployment_env_label_is_macbook(parsed_series):
     for labels, _ in parsed_series["DCGM_FI_DEV_GPU_UTIL"]:
-        assert labels["env"] == "homelab"
+        assert labels["deployment_env"] == "macbook"
+
+
+@pytest.mark.unit
+def test_platform_label_is_docker(parsed_series):
+    for labels, _ in parsed_series["DCGM_FI_DEV_GPU_UTIL"]:
+        assert labels["platform"] == "docker"
 
 
 # ─── Value ranges ─────────────────────────────────────────────────────────────

--- a/tests/component/test_clickhouse.py
+++ b/tests/component/test_clickhouse.py
@@ -29,7 +29,8 @@ EXPECTED_TABLES = [
 TABLE_COLUMNS = {
     "gpu_unified_logs": {
         "timestamp": "DateTime",
-        "env": "String",
+        "deployment_env": "String",
+        "platform": "String",
         "node_id": "String",
         "log_level": "String",
         "message": "String",
@@ -141,8 +142,8 @@ def test_insert_and_select_gpu_unified_logs():
         params={
             "query": (
                 "INSERT INTO gpu_monitoring.gpu_unified_logs "
-                "(timestamp, env, cluster_id, node_id, log_level, source, message, metadata) "
-                "VALUES (now(), 'test', 'test-cluster', 'test-node', 'INFO', 'system', 'test log', '{}')"
+                "(timestamp, deployment_env, platform, cluster_id, node_id, log_level, source, message, metadata) "
+                "VALUES (now(), 'test', 'docker', 'test-cluster', 'test-node', 'INFO', 'system', 'test log', '{}')"
             )
         },
         timeout=5,
@@ -153,7 +154,7 @@ def test_insert_and_select_gpu_unified_logs():
         params={
             "query": (
                 "SELECT count() FROM gpu_monitoring.gpu_unified_logs "
-                "WHERE env='test' AND node_id='test-node'"
+                "WHERE deployment_env='test' AND node_id='test-node'"
             )
         },
         timeout=5,

--- a/tests/e2e/test_e2e_metrics.py
+++ b/tests/e2e/test_e2e_metrics.py
@@ -77,7 +77,7 @@ def test_dcgm_metrics_appear_in_vmselect():
 
 def test_required_labels_on_scraped_metric():
     """
-    Scraped DCGM metrics must carry 'node', 'gpu', 'env', and 'job' labels.
+    Scraped DCGM metrics must carry 'node', 'gpu', 'deployment_env', 'platform', and 'job' labels.
     """
     poll_until(
         lambda: _metric_has_results(_METRIC),
@@ -88,7 +88,7 @@ def test_required_labels_on_scraped_metric():
     body = _query_vmselect(_METRIC)
     for series in body["data"]["result"]:
         labels = series["metric"]
-        for required in ("node", "gpu", "env", "job"):
+        for required in ("node", "gpu", "deployment_env", "platform", "job"):
             assert required in labels, (
                 f"Required label '{required}' missing from series: {labels}"
             )


### PR DESCRIPTION
## Summary
- Renames the overloaded `env` label to `deployment_env` (where: macbook, homelab, corp)
- Adds new `platform` label (how: docker, k8s, baremetal, vm)
- Updates all metric configs (compose, helmfile, file SD targets), Vector agent template, and ClickHouse schema

**PR 1 of 3** in the taxonomy redesign plan (`docs/taxonomy-implementation-plan.md`).

## Files changed
| Layer | Files |
|---|---|
| Docker Compose | `compose/vmagent-config.yaml` |
| Helmfile / K8s | `environments/homelab/vmagent.yaml` |
| File SD targets | `environments/homelab/targets/gpu-nodes.json`, `inference-servers.json`, `environments/corp.example/targets/gpu-nodes.json.example` |
| Ansible / Vector | `ansible/roles/vector-agent/templates/vector-agent.toml.j2` |
| ClickHouse schema | `schemas/gpu_unified_logs.sql` |

## Breaking changes
- Metric label `env` is removed — Grafana dashboards and alert rules referencing `env` must be updated
- ClickHouse `gpu_unified_logs` table schema changes column name and ORDER BY key — existing tables need a migration (out of scope, tracked separately for corp)

## Test plan
- [ ] `docker compose up` with macbook env — verify vmagent scrape config has `deployment_env=macbook, platform=docker`
- [ ] Helmfile diff on homelab — confirm label change in vmagent scrape config
- [ ] Validate ClickHouse schema applies cleanly on a fresh instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)