### PR TITLE
refactor: rename Ansible group gpu_nodes → baremetal_gpu_nodes

### DIFF
--- a/ansible/inventory/homelab.ini
+++ b/ansible/inventory/homelab.ini
@@ -1,9 +1,12 @@
 # Homelab Ansible inventory
 # Add your homelab GPU nodes here.
 
-[gpu_nodes]
+[baremetal_gpu_nodes]
 # homelab-gpu-01 ansible_host=192.168.1.101 ansible_user=ubuntu
 # homelab-gpu-02 ansible_host=192.168.1.102 ansible_user=ubuntu
+
+[vm_gpu_nodes]
+# (placeholder for VMware vGPU/passthrough nodes)
 
 [inference_servers]
 # homelab-infer-01 ansible_host=192.168.1.201 ansible_user=ubuntu

--- a/ansible/playbooks/deploy-node-agents.yaml
+++ b/ansible/playbooks/deploy-node-agents.yaml
@@ -7,7 +7,7 @@
 #   ansible-playbook -i inventory/corp.ini playbooks/deploy-node-agents.yaml  # (symlinked)
 
 - name: Deploy GPU monitoring node agents
-  hosts: gpu_nodes
+  hosts: baremetal_gpu_nodes
   become: true
   vars:
     dcgm_version: "3.3.8-3.6.0-ubuntu22.04"


### PR DESCRIPTION
## Summary
- Renames `[gpu_nodes]` inventory group to `[baremetal_gpu_nodes]`
- Adds `[vm_gpu_nodes]` placeholder group for future VMware GPU node management
- Updates playbook `hosts:` target to match

**PR 3 of 3** in the taxonomy redesign plan (`docs/taxonomy-implementation-plan.md`).
Depends on PR #32 (label rename) being merged first. Independent of PR #33 (File SD rename).

## Files changed
| File | Change |
|---|---|
| `ansible/inventory/homelab.ini` | Group rename + new placeholder group |
| `ansible/playbooks/deploy-node-agents.yaml` | `hosts: gpu_nodes` → `hosts: baremetal_gpu_nodes` |

## Test plan
- [ ] `ansible-inventory -i ansible/inventory/homelab.ini --list` — verify new group names appear
- [ ] `ansible-playbook --syntax-check -i ansible/inventory/homelab.ini ansible/playbooks/deploy-node-agents.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)