### PR TITLE
fix: correct mock-dcgm scrape target service name

### DIFF
--- a/environments/homelab/targets/gpu-nodes.json
+++ b/environments/homelab/targets/gpu-nodes.json
@@ -1,7 +1,7 @@
 [
   {
     "targets": [
-      "mock-dcgm-exporter.monitoring.svc:9400"
+      "mock-dcgm-exporter-mock-dcgm-exporter.monitoring.svc:9400"
     ],
     "labels": {
       "deployment_env": "homelab",

--- a/environments/homelab/vmagent.yaml
+++ b/environments/homelab/vmagent.yaml
@@ -16,7 +16,7 @@ scrapeConfig:
     - job_name: "mock-dcgm"
       static_configs:
         - targets:
-            - "mock-dcgm-exporter.monitoring.svc:9400"
+            - "mock-dcgm-exporter-mock-dcgm-exporter.monitoring.svc:9400"
           labels:
             deployment_env: homelab
             platform: k8s


### PR DESCRIPTION
## Summary
- Fix vmagent scrape target from `mock-dcgm-exporter.monitoring.svc:9400` to `mock-dcgm-exporter-mock-dcgm-exporter.monitoring.svc:9400`
- The Helm release name `mock-dcgm-exporter` gets prefixed to the chart's service name, producing the full name `mock-dcgm-exporter-mock-dcgm-exporter`
- Without this fix, the mock-dcgm target is always **down** due to DNS lookup failure, meaning no GPU metrics flow into VictoriaMetrics

## Test plan
- [ ] Run `make homelab-sync` to apply the config change
- [ ] Verify target is UP: `curl -s http://127.0.0.1:8429/api/v1/targets | grep -A2 '"health"'`
- [ ] Verify metrics exist: query `DCGM_FI_DEV_GPU_UTIL` from VictoriaMetrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)