### PR TITLE
ci: add helmfile template validation and values key checking

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install helmfile
         uses: mamezou-tech/setup-helmfile@v2.0.0
         with:
-          helmfile-version: "0.169.2"
+          helmfile-version: "v0.169.2"
           install-kubectl: false
 
       - name: Install yq

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -33,6 +33,42 @@ jobs:
             helm lint "$chart"
           done
 
+  helmfile-validate:
+    name: helmfile template + values validation
+    runs-on: ubuntu-latest
+    needs: helm-lint
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "3.14.4"
+
+      - name: Install helmfile
+        uses: mamezou-tech/setup-helmfile@v2.0.0
+        with:
+          helmfile-version: "0.169.2"
+          install-kubectl: false
+
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add victoriametrics https://victoriametrics.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add vector https://helm.vector.dev
+          helm repo add clickhouse-operator https://docs.altinity.com/clickhouse-operator
+          helm repo update
+
+      - name: Helmfile template (homelab)
+        run: helmfile -e homelab template > /dev/null
+
+      - name: Validate values keys
+        run: ./scripts/validate-values-keys.sh homelab
+
   helm-unittest:
     name: helm-unittest
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           helmfile-version: "v0.169.2"
           install-kubectl: false
+          install-helm-plugins: false
 
       - name: Install yq
         uses: mikefarah/yq@v4

--- a/Makefile
+++ b/Makefile
@@ -68,5 +68,9 @@ validate-values: ## Check override keys match chart defaults
 	./scripts/validate-values-keys.sh homelab
 
 chart-diff: ## Show values diff between chart versions (CHART=repo/name OLD=x NEW=y)
+	@if [[ -z "$(CHART)" || -z "$(OLD)" || -z "$(NEW)" ]]; then \
+		echo "Usage: make chart-diff CHART=repo/name OLD=x NEW=y" >&2; \
+		exit 2; \
+	fi
 	@diff <(helm show values $(CHART) --version $(OLD)) \
 	      <(helm show values $(CHART) --version $(NEW)) || true

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 .PHONY: help dev-up dev-down homelab-diff homelab-sync build-images lint validate-values chart-diff
 
 REGISTRY ?= ghcr.io/yoonsungnam/gpu-mon

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev-up dev-down homelab-diff homelab-sync build-images lint
+.PHONY: help dev-up dev-down homelab-diff homelab-sync build-images lint validate-values chart-diff
 
 REGISTRY ?= ghcr.io/yoonsungnam/gpu-mon
 TAG      ?= dev
@@ -62,3 +62,10 @@ lint: ## Lint Helm charts and Helmfile
 	helm lint charts/metadata-collector
 	helm lint charts/mock-dcgm-exporter
 	helmfile -e homelab lint
+
+validate-values: ## Check override keys match chart defaults
+	./scripts/validate-values-keys.sh homelab
+
+chart-diff: ## Show values diff between chart versions (CHART=repo/name OLD=x NEW=y)
+	@diff <(helm show values $(CHART) --version $(OLD)) \
+	      <(helm show values $(CHART) --version $(NEW)) || true

--- a/scripts/validate-values-keys.sh
+++ b/scripts/validate-values-keys.sh
@@ -52,7 +52,7 @@ for i in $(seq 0 $((count - 1))); do
     active_keys=$(echo "$chart_defaults" | yq 'keys | .[]' 2>/dev/null)
     # Also capture commented-out top-level keys (e.g. "# adminPassword: ...")
     commented_keys=$(echo "$chart_defaults" \
-      | grep -E '^# [a-zA-Z][a-zA-Z0-9_-]*:' | sed 's/^# //; s/:.*//')
+      | sed -n 's/^# \([a-zA-Z][a-zA-Z0-9_-]*\):.*/\1/p')
     chart_keys=$(printf '%s\n%s\n' "$active_keys" "$commented_keys" | grep -v '^$' | sort -u)
     chart_label="$chart@$version"
   fi

--- a/scripts/validate-values-keys.sh
+++ b/scripts/validate-values-keys.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# validate-values-keys.sh — Detect Helm values override keys that don't exist
+# in the chart's defaults. Reads chart/version/values mapping from helmfile
+# automatically, so no hardcoded list to maintain.
+#
+# Usage:
+#   ./scripts/validate-values-keys.sh [environment]   # default: homelab
+#
+# Prerequisites: helmfile, helm, yq (v4)
+
+set -euo pipefail
+
+ENV="${1:-homelab}"
+exit_code=0
+warnings=0
+
+echo "=== Validating values keys for environment: $ENV ==="
+
+# Render helmfile and extract releases as JSON
+rendered=$(helmfile -e "$ENV" build --quiet 2>/dev/null)
+releases=$(echo "$rendered" | yq -o=json '[.releases[] | {
+  "name": .name,
+  "chart": .chart,
+  "version": .version,
+  "values": .values
+}]')
+
+count=$(echo "$releases" | yq 'length')
+
+for i in $(seq 0 $((count - 1))); do
+  name=$(echo "$releases"  | yq -r ".[$i].name")
+  chart=$(echo "$releases" | yq -r ".[$i].chart")
+  version=$(echo "$releases" | yq -r ".[$i].version // \"\"")
+
+  # Get chart default keys
+  if [[ "$chart" == charts/* ]]; then
+    # Custom chart — read local values.yaml
+    defaults_file="$chart/values.yaml"
+    if [[ ! -f "$defaults_file" ]]; then
+      echo "SKIP [$name]: no values.yaml in $chart"
+      continue
+    fi
+    chart_keys=$(yq 'keys | .[]' "$defaults_file" 2>/dev/null | sort)
+    chart_label="$chart (local)"
+  else
+    # OSS chart — fetch defaults via helm show values
+    if [[ -z "$version" ]]; then
+      echo "SKIP [$name]: no version pinned for $chart"
+      continue
+    fi
+    chart_keys=$(helm show values "$chart" --version "$version" 2>/dev/null \
+      | yq 'keys | .[]' 2>/dev/null | sort)
+    chart_label="$chart@$version"
+  fi
+
+  if [[ -z "$chart_keys" ]]; then
+    echo "SKIP [$name]: could not extract keys from $chart_label"
+    continue
+  fi
+
+  # Check each values file for this release
+  values_json=$(echo "$releases" | yq -o=json ".[$i].values // []")
+  values_count=$(echo "$values_json" | yq 'length')
+
+  for j in $(seq 0 $((values_count - 1))); do
+    vf=$(echo "$values_json" | yq -r ".[$j]")
+
+    # Skip inline values (maps/objects, not file paths)
+    [[ -f "$vf" ]] || continue
+
+    override_keys=$(yq 'keys | .[]' "$vf" 2>/dev/null | sort)
+    [[ -z "$override_keys" ]] && continue
+
+    unknown=$(comm -23 <(echo "$override_keys") <(echo "$chart_keys"))
+    if [[ -n "$unknown" ]]; then
+      echo ""
+      echo "WARNING [$name]: $vf sets keys not found in $chart_label defaults:"
+      echo "$unknown" | sed 's/^/  - /'
+      warnings=$((warnings + 1))
+      exit_code=1
+    fi
+  done
+done
+
+echo ""
+if [[ $exit_code -eq 0 ]]; then
+  echo "OK: All override keys match chart defaults ($count releases checked)."
+else
+  echo "FAILED: $warnings file(s) have unknown keys. See warnings above."
+fi
+
+exit $exit_code

--- a/scripts/validate-values-keys.sh
+++ b/scripts/validate-values-keys.sh
@@ -48,8 +48,12 @@ for i in $(seq 0 $((count - 1))); do
       echo "SKIP [$name]: no version pinned for $chart"
       continue
     fi
-    chart_keys=$(helm show values "$chart" --version "$version" 2>/dev/null \
-      | yq 'keys | .[]' 2>/dev/null | sort)
+    chart_defaults=$(helm show values "$chart" --version "$version" 2>/dev/null)
+    active_keys=$(echo "$chart_defaults" | yq 'keys | .[]' 2>/dev/null)
+    # Also capture commented-out top-level keys (e.g. "# adminPassword: ...")
+    commented_keys=$(echo "$chart_defaults" \
+      | grep -E '^# [a-zA-Z][a-zA-Z0-9_-]*:' | sed 's/^# //; s/:.*//')
+    chart_keys=$(printf '%s\n%s\n' "$active_keys" "$commented_keys" | grep -v '^$' | sort -u)
     chart_label="$chart@$version"
   fi
 


### PR DESCRIPTION
## Summary
- Add `scripts/validate-values-keys.sh` — automated detection of Helm values override keys that don't exist in chart defaults
- Add `helmfile-validate` CI job to `.github/workflows/helm-tests.yml` — runs `helmfile template` (catches rendering failures) and the values key script (catches silently-ignored keys)
- Add `make validate-values` and `make chart-diff` Makefile targets for local use

## Context
During review of PR #39, we found that `metadata-collector.yaml.example` used wrong key paths (`clickhouse:` instead of `config.clickhouse:`), which Helm silently ignores. This validation prevents that class of bug automatically — for both custom charts and OSS charts as they evolve.

The script reads the chart/version/values mapping directly from `helmfile build`, so there is no hardcoded chart list to maintain. Adding or bumping a release in `helmfile.yaml.gotmpl` is automatically covered.

## Test plan
- [ ] `helmfile -e homelab template > /dev/null` renders without error
- [ ] `./scripts/validate-values-keys.sh homelab` passes for all current homelab values files
- [ ] CI `helmfile-validate` job runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)