### PR TITLE
ci: add corp.example template render smoke test

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -104,7 +104,7 @@ jobs:
           for f in environments/corp.example/*.example; do
             cp "$f" "environments/corp/$(basename "${f%.example}")"
           done
-          cp environments/corp.example/targets/*.example environments/corp/targets/ 2>/dev/null || true
+          cp environments/corp.example/targets/*.example environments/corp/targets/ || true
           for f in environments/corp/targets/*.example; do
             mv "$f" "${f%.example}"
           done
@@ -113,11 +113,12 @@ jobs:
         run: |
           charts_dir="$(pwd)/.ci-charts"
           mkdir -p "$charts_dir"
+          # Keep versions in sync with helmfile.yaml.gotmpl
           helm pull victoriametrics/victoria-metrics-cluster --version 0.36.0 -d "$charts_dir"
           helm pull clickhouse-operator/altinity-clickhouse-operator --version 0.26.0 -d "$charts_dir"
           helm pull grafana/grafana --version 10.5.15 -d "$charts_dir"
           helm pull vector/vector --version 0.50.0 -d "$charts_dir"
-          sed -i "s|charts_dir:.*|charts_dir: \"$charts_dir\"|" environments/corp/values.yaml
+          sed -i "s|^charts_dir:.*|charts_dir: \"$charts_dir\"|" environments/corp/values.yaml
 
       - name: Helmfile template (corp.example smoke test)
         run: helmfile -e corp template > /dev/null

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -90,6 +90,9 @@ jobs:
           install-kubectl: false
           install-helm-plugins: false
 
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
       - name: Add Helm repositories
         run: |
           helm repo add victoriametrics https://victoriametrics.github.io/helm-charts
@@ -122,6 +125,9 @@ jobs:
 
       - name: Helmfile template (corp.example smoke test)
         run: helmfile -e corp template > /dev/null
+
+      - name: Validate values keys
+        run: ./scripts/validate-values-keys.sh corp
 
   helm-unittest:
     name: helm-unittest

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -70,6 +70,58 @@ jobs:
       - name: Validate values keys
         run: ./scripts/validate-values-keys.sh homelab
 
+  corp-template-smoke:
+    name: corp.example template render
+    runs-on: ubuntu-latest
+    needs: helm-lint
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "3.14.4"
+
+      - name: Install helmfile
+        uses: mamezou-tech/setup-helmfile@v2.0.0
+        with:
+          helmfile-version: "v0.169.2"
+          install-kubectl: false
+          install-helm-plugins: false
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add victoriametrics https://victoriametrics.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add vector https://helm.vector.dev
+          helm repo add clickhouse-operator https://docs.altinity.com/clickhouse-operator
+          helm repo update
+
+      - name: Prepare corp environment from examples
+        run: |
+          mkdir -p environments/corp/targets
+          for f in environments/corp.example/*.example; do
+            cp "$f" "environments/corp/$(basename "${f%.example}")"
+          done
+          cp environments/corp.example/targets/*.example environments/corp/targets/ 2>/dev/null || true
+          for f in environments/corp/targets/*.example; do
+            mv "$f" "${f%.example}"
+          done
+
+      - name: Download charts for airgap simulation
+        run: |
+          charts_dir="$(pwd)/.ci-charts"
+          mkdir -p "$charts_dir"
+          helm pull victoriametrics/victoria-metrics-cluster --version 0.36.0 -d "$charts_dir"
+          helm pull clickhouse-operator/altinity-clickhouse-operator --version 0.26.0 -d "$charts_dir"
+          helm pull grafana/grafana --version 10.5.15 -d "$charts_dir"
+          helm pull vector/vector --version 0.50.0 -d "$charts_dir"
+          sed -i "s|charts_dir:.*|charts_dir: \"$charts_dir\"|" environments/corp/values.yaml
+
+      - name: Helmfile template (corp.example smoke test)
+        run: helmfile -e corp template > /dev/null
+
   helm-unittest:
     name: helm-unittest
     runs-on: ubuntu-latest

--- a/scripts/validate-values-keys.sh
+++ b/scripts/validate-values-keys.sh
@@ -42,6 +42,14 @@ for i in $(seq 0 $((count - 1))); do
     fi
     chart_keys=$(yq 'keys | .[]' "$defaults_file" 2>/dev/null | sort)
     chart_label="$chart (local)"
+  elif [[ -f "$chart" ]]; then
+    # Packaged chart archive — read defaults directly from the local .tgz
+    chart_defaults=$(helm show values "$chart" 2>/dev/null)
+    active_keys=$(echo "$chart_defaults" | yq 'keys | .[]' 2>/dev/null)
+    commented_keys=$(echo "$chart_defaults" \
+      | sed -n 's/^# \([a-zA-Z][a-zA-Z0-9_-]*\):.*/\1/p')
+    chart_keys=$(printf '%s\n%s\n' "$active_keys" "$commented_keys" | grep -v '^$' | sort -u)
+    chart_label="$chart (archive)"
   else
     # OSS chart — fetch defaults via helm show values
     if [[ -z "$version" ]]; then


### PR DESCRIPTION
## Summary
- Add `corp-template-smoke` CI job to `.github/workflows/helm-tests.yml`
- Copies `environments/corp.example/*.example` → `environments/corp/` (stripping suffix)
- Downloads required chart `.tgz` files via `helm pull` to simulate airgap layout
- Runs `helmfile -e corp template` to catch missing keys, type mismatches, and render errors

## Context
Addresses **R3 (No contract validation between repos)** from `docs/corp-overlay-risk-plan.md` (PR #38, remediation plan PR 2).

When gpu-mon adds a new required values key or changes a chart reference, this job will fail — surfacing the breakage before it reaches the corp cluster.

## Test plan
- [ ] `corp.example template render` CI job passes on this PR
- [ ] Verify that intentionally removing a required key from a `.example` file causes the job to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)