### PR TITLE
fix: align homelab retention with VictoriaMetrics chart setting

### DIFF
--- a/environments/homelab/values.yaml
+++ b/environments/homelab/values.yaml
@@ -16,5 +16,9 @@ mock_dcgm:
 metadata_collector:
   enabled: false
 
+# Override default retention to match VictoriaMetrics chart setting (30d)
+retention:
+  metrics_days: 30
+
 # Ingress / access
 grafana_host: grafana.homelab.local


### PR DESCRIPTION
## Summary
- Override `retention.metrics_days` from default 90 to 30 in `environments/homelab/values.yaml`, matching the VictoriaMetrics chart's `retentionPeriod: "30d"` in `environments/homelab/victoriametrics.yaml`.
- Addresses **R4** (retention settings split across two layers) from the corp-overlay-risk remediation plan.

## Context
`defaults.yaml` sets `retention.metrics_days: 90`, but the homelab VictoriaMetrics Helm values set `retentionPeriod: "30d"`. Without this override, the Helmfile-level retention value (90 days) is inconsistent with the actual chart-level setting (30 days), which could cause confusion when reasoning about data lifecycle.

## Test plan
- [ ] Verify `helmfile template` for homelab still renders correctly
- [ ] Confirm no other environments are affected (only homelab values.yaml changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)