### PR TITLE
fix: add catch-all corp gitignore pattern (R7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 environments/corp/
 ansible/inventory/corp*
 alerting/alertmanager/corp*
+# Catch-all: block any future corp directories across the repo
+**/corp/
 
 # ═══════════════════════════════════════
 # Secrets / sensitive data


### PR DESCRIPTION
## Summary
- Adds `**/corp/` catch-all pattern to `.gitignore` to prevent accidental commits of corp-specific files in any directory (e.g. `dashboards/corp/`, `schemas/corp/`).
- Existing specific patterns (`environments/corp/`, `ansible/inventory/corp*`, `alerting/alertmanager/corp*`) are retained as documentation.
- Addresses **R7** (gitignore gaps for future corp paths) from the corp-overlay-risk-plan.

## Note
The remediation plan also calls for updating `docs/2-repo-plan.md` in the gpu-mon-corp repo. That change is out of scope for this PR since it belongs to a separate repository.

## Test plan
- [x] Verify `git check-ignore dashboards/corp/test.json` matches the new pattern
- [x] Verify existing specific patterns still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)