### PR TITLE
refactor: extract ansible playbook vars into per-environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # ═══════════════════════════════════════
 environments/corp/
 ansible/inventory/corp*
+ansible/vars/corp.yaml
 alerting/alertmanager/corp*
 # Catch-all: block any future corp directories across the repo
 **/corp/

--- a/ansible/playbooks/deploy-node-agents.yaml
+++ b/ansible/playbooks/deploy-node-agents.yaml
@@ -2,18 +2,21 @@
 # Deploy node-level agents (DCGM Exporter + Vector Agent) to GPU nodes.
 # Works for both Baremetal and VM environments.
 #
+# Variables are loaded from external files (ansible/vars/) instead of inline.
+# Corp can override defaults by passing an additional var file.
+#
 # Usage:
-#   ansible-playbook -i inventory/homelab.ini playbooks/deploy-node-agents.yaml
-#   ansible-playbook -i inventory/corp.ini playbooks/deploy-node-agents.yaml  # (symlinked)
+#   ansible-playbook -i inventory/homelab.ini \
+#     -e @vars/defaults.yaml \
+#     playbooks/deploy-node-agents.yaml
+#
+#   ansible-playbook -i inventory/corp.ini \
+#     -e @vars/defaults.yaml -e @vars/corp.yaml \
+#     playbooks/deploy-node-agents.yaml
 
 - name: Deploy GPU monitoring node agents
   hosts: baremetal_gpu_nodes
   become: true
-  vars:
-    dcgm_version: "3.3.8-3.6.0-ubuntu22.04"
-    vector_version: "0.42.0"
-    vector_aggregator_host: "{{ hostvars['k8s-control']['ansible_host'] | default('vector-aggregator.monitoring.svc') }}"
-    vector_aggregator_port: 6000
 
   roles:
     - dcgm-exporter

--- a/ansible/vars/corp.yaml.example
+++ b/ansible/vars/corp.yaml.example
@@ -1,0 +1,21 @@
+---
+# Corp environment variable overrides.
+# Copy to ansible/vars/corp.yaml (in the gpu-mon-corp repo) and fill in
+# real values. Pass after defaults.yaml so these take precedence:
+#
+#   ansible-playbook -i inventory/corp.ini \
+#     -e @vars/defaults.yaml -e @vars/corp.yaml \
+#     playbooks/deploy-node-agents.yaml
+
+# Override versions if corp requires specific builds
+# dcgm_version: "3.3.8-3.6.0-ubuntu22.04"
+# vector_version: "0.42.0"
+
+# Vector aggregator endpoint (use corp-specific host)
+vector_aggregator_host: "YOUR_VECTOR_AGGREGATOR_HOST_HERE"
+# vector_aggregator_port: 6000
+
+# Metadata labels for corp logs
+deployment_env: "corp"
+platform: "baremetal"
+cluster_id: "YOUR_CLUSTER_ID_HERE"

--- a/ansible/vars/defaults.yaml
+++ b/ansible/vars/defaults.yaml
@@ -1,0 +1,19 @@
+---
+# Default variables for GPU monitoring node agent deployment.
+# Override per-environment by passing additional var files:
+#
+#   ansible-playbook -e @vars/defaults.yaml playbooks/deploy-node-agents.yaml
+#   ansible-playbook -e @vars/defaults.yaml -e @vars/corp.yaml playbooks/deploy-node-agents.yaml
+
+# Agent versions
+dcgm_version: "3.3.8-3.6.0-ubuntu22.04"
+vector_version: "0.42.0"
+
+# Vector aggregator endpoint
+vector_aggregator_host: "{{ hostvars['k8s-control']['ansible_host'] | default('vector-aggregator.monitoring.svc') }}"
+vector_aggregator_port: 6000
+
+# Metadata labels injected into forwarded logs
+deployment_env: "homelab"
+platform: "baremetal"
+cluster_id: "default"

--- a/docs/corp-quickstart.md
+++ b/docs/corp-quickstart.md
@@ -27,6 +27,10 @@ cd ~/work/gpu-mon/ansible/inventory/
 ln -s ../../../gpu-mon-corp/ansible/inventory/corp.ini ./corp.ini
 # → Ansible inventory (corp node IPs, SSH config for baremetal/VM agent deployment)
 
+cd ~/work/gpu-mon/ansible/vars/
+ln -s ../../../gpu-mon-corp/ansible/vars/corp.yaml ./corp.yaml
+# → Ansible variable overrides (agent versions, Vector endpoint, metadata labels)
+
 cd ~/work/gpu-mon/alerting/alertmanager/
 ln -s ../../../gpu-mon-corp/alerting/alertmanager/corp.yaml ./corp.yaml
 # → Alertmanager routing (corp notification channels, escalation rules)


### PR DESCRIPTION
## Summary
- Extract inline `vars:` from `deploy-node-agents.yaml` into `ansible/vars/defaults.yaml`
- Add `ansible/vars/corp.yaml.example` with corp-specific override placeholders
- Update playbook usage docs to show `-e @vars/` pattern
- Add missing defaults for `deployment_env`, `platform`, `cluster_id` (used in vector-agent template but previously undefined)

## Context
Addresses **R6 (Ansible lacks per-environment variable overrides)** from `docs/corp-overlay-risk-plan.md` (remediation plan PR 6).

Corp can now override agent versions and endpoints without editing the shared playbook:
```bash
ansible-playbook -i inventory/corp.ini \
  -e @vars/defaults.yaml -e @vars/corp.yaml \
  playbooks/deploy-node-agents.yaml
```

**gpu-mon-corp follow-up needed**: Add `ansible/vars/corp.yaml` with real values and update `scripts/setup-symlinks.sh` to create the new symlink path.

## Test plan
- [ ] `ansible-playbook --syntax-check` passes with `-e @vars/defaults.yaml`
- [ ] Verify that corp.yaml.example overrides take precedence when passed after defaults.yaml
- [ ] Confirm no existing CI jobs are affected (this PR only touches ansible/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)