### PR TITLE
refactor: introduce versions.yaml as SSOT for chart versions

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -116,11 +116,15 @@ jobs:
         run: |
           charts_dir="$(pwd)/.ci-charts"
           mkdir -p "$charts_dir"
-          # Keep versions in sync with helmfile.yaml.gotmpl
-          helm pull victoriametrics/victoria-metrics-cluster --version 0.36.0 -d "$charts_dir"
-          helm pull clickhouse-operator/altinity-clickhouse-operator --version 0.26.0 -d "$charts_dir"
-          helm pull grafana/grafana --version 10.5.15 -d "$charts_dir"
-          helm pull vector/vector --version 0.50.0 -d "$charts_dir"
+          # Read chart versions from versions.yaml (SSOT)
+          helm pull victoriametrics/victoria-metrics-cluster \
+            --version "$(yq '.helm_charts.victoria-metrics-cluster' versions.yaml)" -d "$charts_dir"
+          helm pull clickhouse-operator/altinity-clickhouse-operator \
+            --version "$(yq '.helm_charts.altinity-clickhouse-operator' versions.yaml)" -d "$charts_dir"
+          helm pull grafana/grafana \
+            --version "$(yq '.helm_charts.grafana' versions.yaml)" -d "$charts_dir"
+          helm pull vector/vector \
+            --version "$(yq '.helm_charts.vector' versions.yaml)" -d "$charts_dir"
           sed -i "s|^charts_dir:.*|charts_dir: \"$charts_dir\"|" environments/corp/values.yaml
 
       - name: Helmfile template (corp.example smoke test)

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -118,13 +118,13 @@ jobs:
           mkdir -p "$charts_dir"
           # Read chart versions from versions.yaml (SSOT)
           helm pull victoriametrics/victoria-metrics-cluster \
-            --version "$(yq '.helm_charts.victoria-metrics-cluster' versions.yaml)" -d "$charts_dir"
+            --version "$(yq '.helm_charts["victoria-metrics-cluster"]' versions.yaml)" -d "$charts_dir"
           helm pull clickhouse-operator/altinity-clickhouse-operator \
-            --version "$(yq '.helm_charts.altinity-clickhouse-operator' versions.yaml)" -d "$charts_dir"
+            --version "$(yq '.helm_charts["altinity-clickhouse-operator"]' versions.yaml)" -d "$charts_dir"
           helm pull grafana/grafana \
-            --version "$(yq '.helm_charts.grafana' versions.yaml)" -d "$charts_dir"
+            --version "$(yq '.helm_charts["grafana"]' versions.yaml)" -d "$charts_dir"
           helm pull vector/vector \
-            --version "$(yq '.helm_charts.vector' versions.yaml)" -d "$charts_dir"
+            --version "$(yq '.helm_charts["vector"]' versions.yaml)" -d "$charts_dir"
           sed -i "s|^charts_dir:.*|charts_dir: \"$charts_dir\"|" environments/corp/values.yaml
 
       - name: Helmfile template (corp.example smoke test)

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -10,10 +10,12 @@
 environments:
   homelab:
     values:
+      - versions.yaml
       - environments/defaults.yaml
       - environments/homelab/values.yaml
   corp:
     values:
+      - versions.yaml
       - environments/defaults.yaml
       - environments/corp/values.yaml  # symlinked from gpu-mon-corp
 
@@ -39,10 +41,10 @@ releases:
   - name: victoriametrics
     namespace: monitoring
     {{ if eq .Environment.Name "corp" }}
-    chart: "{{ .Values.charts_dir }}/victoria-metrics-cluster-0.36.0.tgz"
+    chart: "{{ .Values.charts_dir }}/victoria-metrics-cluster-{{ index .Values.helm_charts "victoria-metrics-cluster" }}.tgz"
     {{ else }}
     chart: victoriametrics/victoria-metrics-cluster
-    version: "0.36.0"
+    version: "{{ index .Values.helm_charts "victoria-metrics-cluster" }}"
     {{ end }}
     values:
       - environments/{{ .Environment.Name }}/victoriametrics.yaml
@@ -58,10 +60,10 @@ releases:
   - name: clickhouse-operator
     namespace: clickhouse
     {{ if eq .Environment.Name "corp" }}
-    chart: "{{ .Values.charts_dir }}/altinity-clickhouse-operator-0.26.0.tgz"
+    chart: "{{ .Values.charts_dir }}/altinity-clickhouse-operator-{{ index .Values.helm_charts "altinity-clickhouse-operator" }}.tgz"
     {{ else }}
     chart: clickhouse-operator/altinity-clickhouse-operator
-    version: "0.26.0"
+    version: "{{ index .Values.helm_charts "altinity-clickhouse-operator" }}"
     {{ end }}
 
   # ─── ClickHouse Cluster ───────────────────────────────────────────────────
@@ -77,10 +79,10 @@ releases:
   - name: grafana
     namespace: monitoring
     {{ if eq .Environment.Name "corp" }}
-    chart: "{{ .Values.charts_dir }}/grafana-10.5.15.tgz"
+    chart: "{{ .Values.charts_dir }}/grafana-{{ index .Values.helm_charts "grafana" }}.tgz"
     {{ else }}
     chart: grafana/grafana
-    version: "10.5.15"
+    version: "{{ index .Values.helm_charts "grafana" }}"
     {{ end }}
     values:
       - environments/{{ .Environment.Name }}/grafana.yaml
@@ -89,10 +91,10 @@ releases:
   - name: vector
     namespace: monitoring
     {{ if eq .Environment.Name "corp" }}
-    chart: "{{ .Values.charts_dir }}/vector-0.50.0.tgz"
+    chart: "{{ .Values.charts_dir }}/vector-{{ index .Values.helm_charts "vector" }}.tgz"
     {{ else }}
     chart: vector/vector
-    version: "0.50.0"
+    version: "{{ index .Values.helm_charts "vector" }}"
     {{ end }}
     values:
       - environments/{{ .Environment.Name }}/vector.yaml

--- a/scripts/airgap-bundle.sh
+++ b/scripts/airgap-bundle.sh
@@ -2,7 +2,7 @@
 # Generate an Airgap deployment bundle for corp environment.
 # See docs/corp-deployment-strategy.md for the full deployment guide.
 #
-# Requires: docker, helm, helmfile, curl
+# Requires: docker, helm, helmfile, yq, curl
 # Assumes environments/corp/ is symlinked from gpu-mon-corp repo.
 
 set -euo pipefail
@@ -60,10 +60,15 @@ helm repo add vector https://helm.vector.dev 2>/dev/null || true
 helm repo add clickhouse-operator https://docs.altinity.com/clickhouse-operator 2>/dev/null || true
 helm repo update
 
-helm pull victoriametrics/victoria-metrics-cluster --version 0.36.0 -d "${BUNDLE_DIR}/charts/"
-helm pull grafana/grafana --version 10.5.15 -d "${BUNDLE_DIR}/charts/"
-helm pull vector/vector --version 0.50.0 -d "${BUNDLE_DIR}/charts/"
-helm pull clickhouse-operator/altinity-clickhouse-operator --version 0.26.0 -d "${BUNDLE_DIR}/charts/"
+VERSIONS_FILE="versions.yaml"
+helm pull victoriametrics/victoria-metrics-cluster \
+    --version "$(yq '.helm_charts["victoria-metrics-cluster"]' "$VERSIONS_FILE")" -d "${BUNDLE_DIR}/charts/"
+helm pull grafana/grafana \
+    --version "$(yq '.helm_charts["grafana"]' "$VERSIONS_FILE")" -d "${BUNDLE_DIR}/charts/"
+helm pull vector/vector \
+    --version "$(yq '.helm_charts["vector"]' "$VERSIONS_FILE")" -d "${BUNDLE_DIR}/charts/"
+helm pull clickhouse-operator/altinity-clickhouse-operator \
+    --version "$(yq '.helm_charts["altinity-clickhouse-operator"]' "$VERSIONS_FILE")" -d "${BUNDLE_DIR}/charts/"
 
 for chart_dir in charts/*/; do
     [[ -f "${chart_dir}/Chart.yaml" ]] && helm package "${chart_dir}" -d "${BUNDLE_DIR}/charts/"
@@ -73,6 +78,7 @@ done
 echo "[3/5] Copying deploy files..."
 
 cp helmfile.yaml.gotmpl "${BUNDLE_DIR}/deploy/"
+cp versions.yaml "${BUNDLE_DIR}/deploy/"
 cp environments/defaults.yaml "${BUNDLE_DIR}/deploy/"
 mkdir -p "${BUNDLE_DIR}/deploy/environments"
 cp -rL environments/corp "${BUNDLE_DIR}/deploy/environments/corp"

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,0 +1,27 @@
+# versions.yaml — Single source of truth for all image and chart versions.
+# Read by: helmfile.yaml.gotmpl, CI workflows, corp-sync-images.sh
+# See: docs/corp-deployment-strategy.md (D24)
+
+custom_images:
+  mock-dcgm-exporter: "v1.0.0"
+  metadata-collector: "v1.0.0"
+
+oss_images:
+  victoriametrics/vminsert: "v1.106.1"
+  victoriametrics/vmselect: "v1.106.1"
+  victoriametrics/vmstorage: "v1.106.1"
+  victoriametrics/vmagent: "v1.106.1"
+  victoriametrics/vmalert: "v1.106.1"
+  clickhouse/clickhouse-server: "24.8"
+  altinity/clickhouse-operator: "0.24.0"
+  grafana/grafana: "11.4.0"
+  timberio/vector: "0.42.0-alpine"
+  prom/alertmanager: "v0.27.0"
+  prom/node-exporter: "v1.8.2"
+  registry.k8s.io/kube-state-metrics/kube-state-metrics: "v2.14.0"
+
+helm_charts:
+  victoria-metrics-cluster: "0.36.0"
+  altinity-clickhouse-operator: "0.26.0"
+  grafana: "10.5.15"
+  vector: "0.50.0"


### PR DESCRIPTION
## Summary
- Add `versions.yaml` as the single source of truth for all image and chart versions (D24)
- Update `helmfile.yaml.gotmpl` to read chart versions from `.Values.helm_charts` instead of inline literals
- Update CI `corp-template-smoke` job to read versions from `versions.yaml` via `yq` instead of hardcoded values

## Context
Addresses **R2 (Chart version coupling in .tgz filenames)** from `docs/corp-overlay-risk-plan.md` — the final PR in the remediation plan.

Previously, chart versions were duplicated in three places:
1. `helmfile.yaml.gotmpl` (inline version strings + `.tgz` filenames)
2. `.github/workflows/helm-tests.yml` (hardcoded `helm pull --version` args)
3. `docs/corp-deployment-strategy.md` (design reference)

Now a version bump requires editing only `versions.yaml`. Helmfile, CI, and future scripts (`corp-sync-images.sh`, `airgap-bundle.sh`) all read from the same file.

## Files changed
- `versions.yaml` (new) — chart versions + image versions per D24 design
- `helmfile.yaml.gotmpl` — loads `versions.yaml` as values, uses `index .Values.helm_charts` for chart/version references
- `.github/workflows/helm-tests.yml` — `helm pull` reads versions via `yq` from `versions.yaml`

## Test plan
- [ ] `helmfile -e homelab template` renders correctly with versions from `versions.yaml`
- [ ] `corp.example template render` CI job passes (validates corp airgap path)
- [ ] `helmfile template + values validation` CI job passes (validates homelab path)
- [ ] Verify that changing a version in `versions.yaml` propagates to both helmfile and CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)