### PR TITLE
fix: disable validation on clickhouse release for fresh deploys

### DIFF
--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -70,6 +70,7 @@ releases:
   - name: clickhouse
     namespace: clickhouse
     chart: charts/clickhouse-cluster
+    disableValidation: true  # CRD from clickhouse-operator may not exist during first diff
     needs:
       - clickhouse/clickhouse-operator
     values:

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -70,7 +70,7 @@ releases:
   - name: clickhouse
     namespace: clickhouse
     chart: charts/clickhouse-cluster
-    disableValidation: true  # CRD from clickhouse-operator may not exist during first diff
+    disableValidationOnInstall: true  # CRD may be absent until clickhouse-operator installs it
     needs:
       - clickhouse/clickhouse-operator
     values:


### PR DESCRIPTION
## Summary
- Add `disableValidation: true` to the clickhouse release in helmfile
- Fixes `no matches for kind "ClickHouseInstallation"` error on first `helmfile diff/sync` when the CRD from clickhouse-operator hasn't been installed yet

## Context
`helmfile diff` validates all manifests against the cluster API before applying. On a fresh cluster, the `ClickHouseInstallation` CRD doesn't exist yet, so validation fails even though the `needs` dependency would install the operator first during sync.

## Test plan
- [ ] `make corp-deploy` succeeds on a fresh cluster without pre-installing the operator
- [ ] `helmfile -e homelab diff` still works on existing clusters