### PR TITLE
fix: resolve vmagent CrashLoopBackOff from unsupported refresh_interval

### DIFF
--- a/charts/vmagent-central/templates/deployment.yaml
+++ b/charts/vmagent-central/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
             - "-remoteWrite.url={{ .url }}"
             {{- end }}
             - "-httpListenAddr=:{{ .Values.service.port }}"
+            {{- range .Values.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/vmagent-central/tests/deployment_test.yaml
+++ b/charts/vmagent-central/tests/deployment_test.yaml
@@ -30,6 +30,16 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "-remoteWrite.url=http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
 
+  - it: passes extraArgs when set
+    documentIndex: 0
+    set:
+      extraArgs:
+        - "-promscrape.fileSDCheckInterval=60s"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-promscrape.fileSDCheckInterval=60s"
+
   - it: exposes port 8429
     documentIndex: 0
     asserts:

--- a/charts/vmagent-central/values.yaml
+++ b/charts/vmagent-central/values.yaml
@@ -9,6 +9,9 @@ image:
 remoteWrite:
   - url: "http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
 
+# Extra CLI flags passed to vmagent (e.g. -promscrape.fileSDCheckInterval=60s)
+extraArgs: []
+
 # Full vmagent scrape configuration (merged by environment values)
 scrapeConfig: {}
 

--- a/docs/planning-v5.ko.md
+++ b/docs/planning-v5.ko.md
@@ -233,7 +233,7 @@ scrape_configs:
     scrape_interval: 15s
     file_sd_configs:
       - files: ["/etc/vmagent/sd/baremetal-gpu-nodes.json"]
-        refresh_interval: 60s    # 파일 변경 감지 주기
+        # Note: refresh interval은 CLI 플래그 -promscrape.fileSDCheckInterval로 설정 (기본 60s)
     relabel_configs:
       - source_labels: [__address__]
         regex: "(.+):.*"
@@ -242,7 +242,6 @@ scrape_configs:
   - job_name: "baremetal-node-exporter"
     file_sd_configs:
       - files: ["/etc/vmagent/sd/baremetal-node-exporters.json"]
-        refresh_interval: 60s
     relabel_configs:
       - source_labels: [__address__]
         regex: "(.+):.*"
@@ -254,7 +253,6 @@ scrape_configs:
   - job_name: "vm-dcgm"
     file_sd_configs:
       - files: ["/etc/vmagent/sd/vm-gpu-nodes.json"]
-        refresh_interval: 60s
 
   # ────────────────────────────────────────
   # K8s 클러스터 (K8s SD 자동)
@@ -283,7 +281,6 @@ scrape_configs:
   - job_name: "inference-servers"
     file_sd_configs:
       - files: ["/etc/vmagent/sd/inference-servers.json"]
-        refresh_interval: 60s
 ```
 
 **File-based Service Discovery (Ansible 관리):**
@@ -322,7 +319,7 @@ File SD 운영 흐름:
 
   1. 노드 추가/제거 시:
      Ansible playbook → JSON 파일 갱신 → K8s ConfigMap 업데이트
-     vmagent이 refresh_interval (60초)마다 파일을 다시 읽음
+     vmagent이 60초마다 파일을 다시 읽음 (-promscrape.fileSDCheckInterval로 설정)
      → 자동으로 새 노드 scrape 시작 / 제거된 노드 scrape 중단
 
   2. scrape 주기/라벨 변경 시:

--- a/docs/planning-v5.md
+++ b/docs/planning-v5.md
@@ -233,7 +233,7 @@ scrape_configs:
     scrape_interval: 15s
     file_sd_configs:
       - files: ["/etc/vmagent/sd/baremetal-gpu-nodes.json"]
-        refresh_interval: 60s    # File change detection interval
+        # Note: refresh interval is set via CLI flag -promscrape.fileSDCheckInterval (default 60s)
     relabel_configs:
       - source_labels: [__address__]
         regex: "(.+):.*"
@@ -242,7 +242,6 @@ scrape_configs:
   - job_name: "baremetal-node-exporter"
     file_sd_configs:
       - files: ["/etc/vmagent/sd/baremetal-node-exporters.json"]
-        refresh_interval: 60s
     relabel_configs:
       - source_labels: [__address__]
         regex: "(.+):.*"
@@ -254,7 +253,6 @@ scrape_configs:
   - job_name: "vm-dcgm"
     file_sd_configs:
       - files: ["/etc/vmagent/sd/vm-gpu-nodes.json"]
-        refresh_interval: 60s
 
   # ────────────────────────────────────────
   # K8s Clusters (K8s SD auto)
@@ -283,7 +281,6 @@ scrape_configs:
   - job_name: "inference-servers"
     file_sd_configs:
       - files: ["/etc/vmagent/sd/inference-servers.json"]
-        refresh_interval: 60s
 ```
 
 **File-based Service Discovery (Ansible-managed):**
@@ -322,7 +319,7 @@ File SD Operations Flow:
 
   1. When nodes are added/removed:
      Ansible playbook → Update JSON file → Update K8s ConfigMap
-     vmagent re-reads the file every refresh_interval (60 seconds)
+     vmagent re-reads the file every 60s (set via -promscrape.fileSDCheckInterval)
      → Automatically starts scraping new nodes / stops scraping removed nodes
 
   2. When scrape interval/labels change:

--- a/environments/corp.example/vmagent.yaml.example
+++ b/environments/corp.example/vmagent.yaml.example
@@ -6,6 +6,9 @@ replicaCount: 2   # HA pair
 remoteWrite:
   - url: "http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
 
+extraArgs:
+  - "-promscrape.fileSDCheckInterval=60s"
+
 scrapeConfig:
   global:
     scrape_interval: 15s
@@ -15,7 +18,6 @@ scrapeConfig:
     - job_name: "baremetal-dcgm"
       file_sd_configs:
         - files: ["/etc/vmagent/sd/baremetal-gpu-nodes.json"]
-          refresh_interval: 60s
       relabel_configs:
         - source_labels: [__address__]
           regex: "(.+):.*"
@@ -24,7 +26,6 @@ scrapeConfig:
     - job_name: "baremetal-node-exporter"
       file_sd_configs:
         - files: ["/etc/vmagent/sd/baremetal-gpu-nodes.json"]
-          refresh_interval: 60s
       relabel_configs:
         - source_labels: [__address__]
           regex: "(.+):[0-9]+"
@@ -38,13 +39,11 @@ scrapeConfig:
     - job_name: "vm-dcgm"
       file_sd_configs:
         - files: ["/etc/vmagent/sd/vm-gpu-nodes.json"]
-          refresh_interval: 60s
 
     # ── Inference servers ──────────────────────────────────────────────────
     - job_name: "inference-servers"
       file_sd_configs:
         - files: ["/etc/vmagent/sd/inference-servers.json"]
-          refresh_interval: 60s
       relabel_configs:
         - source_labels: [__address__]
           regex: "(.+):.*"

--- a/environments/homelab/vmagent.yaml
+++ b/environments/homelab/vmagent.yaml
@@ -50,10 +50,10 @@ scrapeConfig:
     # ── File SD: Baremetal GPU nodes (Ansible-managed) ────────────────────
     # Used in corp/homelab when baremetal nodes exist.
     # Empty in homelab (mock exporter handles this role).
+    # Note: refresh interval is set via extraArgs (-promscrape.fileSDCheckInterval).
     # - job_name: "baremetal-dcgm"
     #   file_sd_configs:
     #     - files: ["/etc/vmagent/sd/baremetal-gpu-nodes.json"]
-    #       refresh_interval: 60s
 
 resources:
   requests:


### PR DESCRIPTION
## Summary
- vmagent's config parser does not support Prometheus's `refresh_interval` field inside `file_sd_configs`, causing CrashLoopBackOff in corp environment
- Removed `refresh_interval` from all `file_sd_configs` entries in the scrape config
- Added `extraArgs` Helm value to the vmagent-central chart, allowing CLI flags like `-promscrape.fileSDCheckInterval=60s` to be passed — this is vmagent's equivalent mechanism

## Files changed
- `charts/vmagent-central/values.yaml` — add `extraArgs: []` 
- `charts/vmagent-central/templates/deployment.yaml` — render `extraArgs` into container args
- `environments/corp.example/vmagent.yaml.example` — remove `refresh_interval`, add `extraArgs` with the CLI flag
- `environments/homelab/vmagent.yaml` — update commented file_sd example

## Test plan
- [x] `helm template` renders correctly with corp example values (no `refresh_interval` in config, CLI flag present in args)
- [x] `helm template` renders correctly with homelab values (no extra args injected)
- [ ] Deploy to corp cluster and verify vmagent starts without CrashLoopBackOff
- [ ] Verify file SD targets are discovered with 60s refresh interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)