### PR TITLE
feat: add Spectrum Scale StorageClass template for corp PVCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ corp-deploy: corp-preflight ## Sync images + deploy to corp cluster (one-touch)
 	elif [ -f environments/corp/storageclass.yaml ]; then \
 		echo "Creating StorageClass spectrum-scale..."; \
 		kubectl apply -f environments/corp/storageclass.yaml; \
+	else \
+		echo "ERROR: StorageClass spectrum-scale not found in cluster and environments/corp/storageclass.yaml is missing." >&2; \
+		echo "  Copy environments/corp.example/storageclass.yaml.example → environments/corp/storageclass.yaml and fill in values." >&2; \
+		exit 1; \
 	fi
 	helmfile -e corp diff
 	helmfile -e corp sync

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,14 @@ corp-pull-charts: corp-preflight ## Pull OSS Helm charts to local .tgz cache (ai
 
 corp-deploy: corp-preflight ## Sync images + deploy to corp cluster (one-touch)
 	./scripts/corp-sync-images.sh $(CORP_REGISTRY)
+	@# StorageClass is a cluster-scoped prerequisite, not managed by Helmfile.
+	@# Only create if absent — avoids overwriting an SC managed externally.
+	@if kubectl get sc spectrum-scale >/dev/null 2>&1; then \
+		echo "StorageClass spectrum-scale already exists, skipping"; \
+	elif [ -f environments/corp/storageclass.yaml ]; then \
+		echo "Creating StorageClass spectrum-scale..."; \
+		kubectl apply -f environments/corp/storageclass.yaml; \
+	fi
 	helmfile -e corp diff
 	helmfile -e corp sync
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: help dev-up dev-down homelab-diff homelab-sync build-images build-grafana-plugins lint validate-values chart-diff corp-preflight corp-diff corp-sync corp-deploy corp-pull-charts corp-bundle
+.PHONY: help dev-up dev-down homelab-diff homelab-sync build-images build-grafana-plugins lint validate-values chart-diff corp-preflight corp-ensure-sc corp-diff corp-sync corp-deploy corp-pull-charts corp-bundle
 
 REGISTRY        ?= ghcr.io/yoonsungnam/gpu-mon
 TAG             ?= dev
@@ -44,14 +44,7 @@ corp-preflight: ## Validate corp symlinks and required files
 corp-diff: corp-preflight ## Show pending Helm changes for corp env (requires gpu-mon-corp symlink)
 	helmfile -e corp diff
 
-corp-sync: corp-preflight ## Deploy to corp K8s cluster
-	helmfile -e corp sync
-
-corp-pull-charts: corp-preflight ## Pull OSS Helm charts to local .tgz cache (airgap prep)
-	./scripts/corp-pull-charts.sh $(CORP_CHARTS_DIR)
-
-corp-deploy: corp-preflight ## Sync images + deploy to corp cluster (one-touch)
-	./scripts/corp-sync-images.sh $(CORP_REGISTRY)
+corp-ensure-sc: corp-preflight ## Ensure required StorageClass exists for corp PVCs
 	@# StorageClass is a cluster-scoped prerequisite, not managed by Helmfile.
 	@# Only create if absent — avoids overwriting an SC managed externally.
 	@if kubectl get sc spectrum-scale >/dev/null 2>&1; then \
@@ -64,6 +57,15 @@ corp-deploy: corp-preflight ## Sync images + deploy to corp cluster (one-touch)
 		echo "  Copy environments/corp.example/storageclass.yaml.example → environments/corp/storageclass.yaml and fill in values." >&2; \
 		exit 1; \
 	fi
+
+corp-sync: corp-ensure-sc ## Deploy to corp K8s cluster
+	helmfile -e corp sync
+
+corp-pull-charts: corp-preflight ## Pull OSS Helm charts to local .tgz cache (airgap prep)
+	./scripts/corp-pull-charts.sh $(CORP_CHARTS_DIR)
+
+corp-deploy: corp-ensure-sc ## Sync images + deploy to corp cluster (one-touch)
+	./scripts/corp-sync-images.sh $(CORP_REGISTRY)
 	helmfile -e corp diff
 	helmfile -e corp sync
 

--- a/docs/corp-deployment-strategy.md
+++ b/docs/corp-deployment-strategy.md
@@ -236,6 +236,16 @@ echo "=== Sync complete ==="
 ```makefile
 corp-deploy: corp-preflight ## Sync images + deploy to corp cluster (one-touch)
 	./scripts/corp-sync-images.sh $(CORP_REGISTRY)
+	@# StorageClass: create if absent, skip if exists, fail if file missing
+	@if kubectl get sc spectrum-scale >/dev/null 2>&1; then \
+		echo "StorageClass spectrum-scale already exists, skipping"; \
+	elif [ -f environments/corp/storageclass.yaml ]; then \
+		echo "Creating StorageClass spectrum-scale..."; \
+		kubectl apply -f environments/corp/storageclass.yaml; \
+	else \
+		echo "ERROR: StorageClass spectrum-scale not found and manifest missing"; \
+		exit 1; \
+	fi
 	helmfile -e corp diff
 	helmfile -e corp sync
 

--- a/docs/corp-deployment-strategy.md
+++ b/docs/corp-deployment-strategy.md
@@ -234,8 +234,7 @@ echo "=== Sync complete ==="
 ### Makefile Targets
 
 ```makefile
-corp-deploy: corp-preflight ## Sync images + deploy to corp cluster (one-touch)
-	./scripts/corp-sync-images.sh $(CORP_REGISTRY)
+corp-ensure-sc: corp-preflight ## Ensure required StorageClass exists for corp PVCs
 	@# StorageClass: create if absent, skip if exists, fail if file missing
 	@if kubectl get sc spectrum-scale >/dev/null 2>&1; then \
 		echo "StorageClass spectrum-scale already exists, skipping"; \
@@ -246,10 +245,13 @@ corp-deploy: corp-preflight ## Sync images + deploy to corp cluster (one-touch)
 		echo "ERROR: StorageClass spectrum-scale not found and manifest missing"; \
 		exit 1; \
 	fi
-	helmfile -e corp diff
+
+corp-sync: corp-ensure-sc ## Deploy to corp K8s cluster (helmfile only, no image sync)
 	helmfile -e corp sync
 
-corp-sync: corp-preflight ## Deploy to corp K8s cluster (helmfile only, no image sync)
+corp-deploy: corp-ensure-sc ## Sync images + deploy to corp cluster (one-touch)
+	./scripts/corp-sync-images.sh $(CORP_REGISTRY)
+	helmfile -e corp diff
 	helmfile -e corp sync
 ```
 

--- a/docs/corp-quickstart.md
+++ b/docs/corp-quickstart.md
@@ -86,8 +86,9 @@ Notes:
 
 1. `corp-sync-images.sh` reads `versions.yaml`, pulls images from GHCR/DockerHub, and pushes them to the corp registry
 2. This includes the `grafana-plugins` carrier image when it is listed under `custom_images`
-3. `helmfile -e corp diff` previews changes
-4. `helmfile -e corp sync` deploys to the cluster
+3. StorageClass `spectrum-scale` is created if absent in the cluster (skipped if it already exists; fails if the manifest file is missing)
+4. `helmfile -e corp diff` previews changes
+5. `helmfile -e corp sync` deploys to the cluster
 
 If `grafana_plugins_init: true` is set in `environments/corp/values.yaml`, the
 Grafana release mounts an `emptyDir`, runs an init container from the

--- a/docs/corp-quickstart.md
+++ b/docs/corp-quickstart.md
@@ -84,9 +84,9 @@ Notes:
 
 ## What `make corp-deploy` does
 
-1. `corp-sync-images.sh` reads `versions.yaml`, pulls images from GHCR/DockerHub, and pushes them to the corp registry
-2. This includes the `grafana-plugins` carrier image when it is listed under `custom_images`
-3. StorageClass `spectrum-scale` is created if absent in the cluster (skipped if it already exists; fails if the manifest file is missing)
+1. Pre-flight validation (`validate-corp-setup.sh`) checks symlinks and required files
+2. StorageClass `spectrum-scale` is created if absent in the cluster (skipped if it already exists; fails if the manifest file is missing)
+3. `corp-sync-images.sh` reads `versions.yaml`, pulls images from GHCR/DockerHub, and pushes them to the corp registry (includes the `grafana-plugins` carrier image when listed under `custom_images`)
 4. `helmfile -e corp diff` previews changes
 5. `helmfile -e corp sync` deploys to the cluster
 

--- a/environments/corp.example/README.md
+++ b/environments/corp.example/README.md
@@ -15,6 +15,7 @@ Actual production values live in a separate private repo and are symlinked here 
 | `grafana.yaml.example` | Grafana datasources, dashboards, ingress, and plugins |
 | `vector.yaml.example` | Vector aggregator sources, transforms, and ClickHouse sink |
 | `metadata-collector.yaml.example` | Metadata collector S2/VMware integration |
+| `storageclass.yaml.example` | StorageClass for IBM Spectrum Scale CSI (apply before helmfile sync) |
 | `targets/baremetal-gpu-nodes.json.example` | File SD target list for Baremetal GPU nodes |
 | `targets/vm-gpu-nodes.json.example` | File SD target list for VMware GPU VMs |
 | `targets/inference-servers.json.example` | File SD target list for inference servers |

--- a/environments/corp.example/README.md
+++ b/environments/corp.example/README.md
@@ -20,9 +20,11 @@ Actual production values live in a separate private repo and are symlinked here 
 | `targets/vm-gpu-nodes.json.example` | File SD target list for VMware GPU VMs |
 | `targets/inference-servers.json.example` | File SD target list for inference servers |
 
-All YAML files above are required for `helmfile -e corp sync` to succeed
-(except `metadata-collector.yaml.example`, which is only needed when
-`metadata_collector.enabled: true` in `values.yaml`).
+All Helm values YAML files above are required for `helmfile -e corp sync`
+to succeed (except `metadata-collector.yaml.example`, which is only needed
+when `metadata_collector.enabled: true` in `values.yaml`).
+`storageclass.yaml.example` is a separate cluster prerequisite used by
+`make corp-deploy` and `make corp-sync` when the StorageClass is absent.
 Target JSON files are required when the corresponding scrape jobs are
 configured in `vmagent.yaml`.
 
@@ -31,7 +33,7 @@ configured in `vmagent.yaml`.
 `storageclass.yaml` defines a cluster-scoped StorageClass required by
 VictoriaMetrics and ClickHouse PVCs. It is **not** managed by Helmfile.
 
-`make corp-deploy` handles it automatically:
+`make corp-deploy` and `make corp-sync` handle it automatically:
 - If the StorageClass already exists in the cluster, it is **skipped**
   (safe when the SC is managed externally, e.g. by the storage team).
 - If it is absent and `environments/corp/storageclass.yaml` exists on disk,

--- a/environments/corp.example/README.md
+++ b/environments/corp.example/README.md
@@ -26,6 +26,19 @@ All YAML files above are required for `helmfile -e corp sync` to succeed
 Target JSON files are required when the corresponding scrape jobs are
 configured in `vmagent.yaml`.
 
+## StorageClass lifecycle
+
+`storageclass.yaml` defines a cluster-scoped StorageClass required by
+VictoriaMetrics and ClickHouse PVCs. It is **not** managed by Helmfile.
+
+`make corp-deploy` handles it automatically:
+- If the StorageClass already exists in the cluster, it is **skipped**
+  (safe when the SC is managed externally, e.g. by the storage team).
+- If it is absent and `environments/corp/storageclass.yaml` exists on disk,
+  it is created via `kubectl apply`.
+- To update an existing SC, delete it first then re-run:
+  `kubectl delete sc spectrum-scale && make corp-deploy`
+
 ## Usage
 
 ```bash
@@ -36,6 +49,6 @@ for f in targets/*.example; do cp "$f" "${f%.example}"; done
 # 2. Edit with your actual infrastructure details
 vim values.yaml
 
-# 3. Deploy
-helmfile -e corp sync
+# 3. Deploy (applies StorageClass if needed, then helmfile sync)
+make corp-deploy
 ```

--- a/environments/corp.example/clickhouse.yaml.example
+++ b/environments/corp.example/clickhouse.yaml.example
@@ -13,6 +13,7 @@ clickhouse:
       replicasCount: 2           # Replicas for HA
   storage:
     size: 100Gi                  # Adjust based on log volume and retention
+    storageClassName: "spectrum-scale"
   resources:
     requests:
       cpu: "2"

--- a/environments/corp.example/storageclass.yaml.example
+++ b/environments/corp.example/storageclass.yaml.example
@@ -1,0 +1,17 @@
+# StorageClass for IBM Spectrum Scale CSI — template.
+# Copy to environments/corp/storageclass.yaml (in the private repo)
+# and fill in the actual filesystem name.
+#
+# Apply before helmfile sync:
+#   kubectl apply -f environments/corp/storageclass.yaml
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: spectrum-scale
+provisioner: spectrumscale.csi.ibm.com
+parameters:
+  volBackendFs: "YOUR_GPFS_FILESYSTEM_HERE"   # e.g. gpfs01
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+volumeBindingMode: Immediate

--- a/environments/corp.example/storageclass.yaml.example
+++ b/environments/corp.example/storageclass.yaml.example
@@ -2,7 +2,9 @@
 # Copy to environments/corp/storageclass.yaml (in the private repo)
 # and fill in the actual filesystem name.
 #
-# Apply before helmfile sync:
+# Primary path: `make corp-deploy` or `make corp-sync` will apply this
+# automatically if `spectrum-scale` does not already exist in the cluster.
+# Manual path (optional):
 #   kubectl apply -f environments/corp/storageclass.yaml
 
 apiVersion: storage.k8s.io/v1

--- a/environments/corp.example/victoriametrics.yaml.example
+++ b/environments/corp.example/victoriametrics.yaml.example
@@ -21,6 +21,7 @@ vmstorage:
   persistentVolume:
     enabled: true
     size: 200Gi                  # Adjust based on GPU node count and retention
+    storageClassName: "spectrum-scale"
   retentionPeriod: "90d"         # Must align with retention.metrics_days in values.yaml
   resources:
     requests:


### PR DESCRIPTION
## Summary
- Add `storageclass.yaml.example` template for IBM Spectrum Scale CSI driver
- Add `storageClassName: "spectrum-scale"` to VictoriaMetrics and ClickHouse example values
- Document the new file in `corp.example/README.md`
- Add StorageClass apply-if-absent logic to `make corp-deploy`

Companion PR: gpu-mon-corp#14 (applies the actual SC manifest and values)

## Context
`vmstorage-0` pod is pending in corp with unbound PVC errors because no StorageClass exists on the cluster. The corp cluster uses `ibm-spectrum-scale-csi-driver` — this PR adds the template and wires `storageClassName` into both StatefulSet components (vmstorage, ClickHouse).

## StorageClass lifecycle
The StorageClass is a cluster-scoped prerequisite **not managed by Helmfile**.
`make corp-deploy` now handles it automatically:
- **SC exists** → skipped (safe when managed externally, e.g. by the storage team)
- **SC absent + manifest on disk** → created via `kubectl apply`
- **Force-update** → `kubectl delete sc spectrum-scale && make corp-deploy`

This avoids ping-pong with externally managed StorageClasses while ensuring
fresh clusters get the SC without manual steps.

## Test plan
- [ ] Verify `storageclass.yaml.example` is valid K8s manifest
- [ ] Verify `storageClassName` field is accepted by victoria-metrics-cluster chart
- [ ] Verify `storageClassName` field is accepted by clickhouse-cluster chart (already supported in `charts/clickhouse-cluster/templates/clickhouseinstallation.yaml`)
- [ ] Verify `make corp-deploy` skips SC when it already exists
- [ ] Verify `make corp-deploy` creates SC when absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)