### PR TITLE
fix: add missing fileSD section to corp vmagent example template

### DIFF
--- a/environments/corp.example/vmagent.yaml.example
+++ b/environments/corp.example/vmagent.yaml.example
@@ -6,6 +6,10 @@ replicaCount: 2   # HA pair
 remoteWrite:
   - url: "http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
 
+fileSD:
+  enabled: true
+  configMapName: vmagent-file-sd
+
 extraArgs:
   - "-promscrape.fileSDCheckInterval=60s"
 


### PR DESCRIPTION
## Summary
- Add `fileSD.enabled: true` and `fileSD.configMapName: vmagent-file-sd` to `environments/corp.example/vmagent.yaml.example`

## Context
The corp example template defines `file_sd_configs` referencing `/etc/vmagent/sd/*.json`, but was missing the `fileSD` section that enables the volume mount in the `vmagent-central` chart (`charts/vmagent-central/templates/deployment.yaml:40-43,62-65`). Without `fileSD.enabled: true`, the ConfigMap volume is never mounted and vmagent fails to read the target files.

Found during review of `gpu-mon-corp` PR #13, which fixed the real corp overlay with the same change.

## Test plan
- [ ] `helm template vmagent-central charts/vmagent-central -f environments/corp.example/vmagent.yaml.example` renders the `file-sd` volumeMount and volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)