### PR TITLE
fix: handle StatefulSet immutable field errors during helmfile sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ homelab-diff: ## Show pending Helm changes for homelab env
 	helmfile -e homelab diff
 
 homelab-sync: ## Deploy to homelab K8s cluster
-	helmfile -e homelab sync
+	./scripts/helmfile-sync.sh homelab
 
 homelab-destroy: ## Destroy homelab deployment (irreversible)
 	helmfile -e homelab destroy
@@ -59,7 +59,7 @@ corp-ensure-sc: corp-preflight ## Ensure required StorageClass exists for corp P
 	fi
 
 corp-sync: corp-ensure-sc ## Deploy to corp K8s cluster
-	helmfile -e corp sync
+	./scripts/helmfile-sync.sh corp
 
 corp-pull-charts: corp-preflight ## Pull OSS Helm charts to local .tgz cache (airgap prep)
 	./scripts/corp-pull-charts.sh $(CORP_CHARTS_DIR)
@@ -67,7 +67,7 @@ corp-pull-charts: corp-preflight ## Pull OSS Helm charts to local .tgz cache (ai
 corp-deploy: corp-ensure-sc ## Sync images + deploy to corp cluster (one-touch)
 	./scripts/corp-sync-images.sh $(CORP_REGISTRY)
 	helmfile -e corp diff
-	helmfile -e corp sync
+	./scripts/helmfile-sync.sh corp
 
 corp-bundle: corp-preflight ## Generate Airgap bundle for corp deployment
 	./scripts/airgap-bundle.sh

--- a/docs/corp-quickstart.md
+++ b/docs/corp-quickstart.md
@@ -94,8 +94,8 @@ The wrapper auto-recovers from StatefulSet immutable field errors (e.g. PVC size
 or storageClassName changes on vmstorage) by orphan-deleting only allowlisted
 StatefulSets and retrying the sync. Pods and PVCs remain running throughout.
 
-See [`scripts/helmfile-sync.sh`](../scripts/helmfile-sync.sh) for the full
-implementation, allowlist, and safety guards.
+See [Helmfile Sync Retry Flow](helmfile-sync.md) for the full flow description,
+safety guards, and flowchart.
 
 ## Rollback
 

--- a/docs/corp-quickstart.md
+++ b/docs/corp-quickstart.md
@@ -79,12 +79,91 @@ To build locally (e.g. for testing): `make build-grafana-plugins`
 2. StorageClass `spectrum-scale` is created if absent in the cluster (skipped if it already exists; fails if the manifest file is missing)
 3. `corp-sync-images.sh` reads `versions.yaml`, pulls images from GHCR/DockerHub, and pushes them to the corp registry (includes the `grafana-plugins` carrier image when listed under `custom_images`)
 4. `helmfile -e corp diff` previews changes
-5. `helmfile -e corp sync` deploys to the cluster
+5. `./scripts/helmfile-sync.sh corp` runs the Helmfile sync with a narrow StatefulSet immutable-field recovery path
 
 If `grafana_plugins_init: true` is set in `environments/corp/values.yaml`, the
 Grafana release mounts an `emptyDir`, runs an init container from the
 `grafana-plugins` image, and starts Grafana with `plugins: []` so no internet
 download is required from the cluster.
+
+## Helmfile sync retry flow
+
+`make corp-deploy`, `make corp-sync`, and `make homelab-sync` all call
+`./scripts/helmfile-sync.sh <environment>` instead of invoking `helmfile sync`
+directly.
+
+The wrapper exists for one specific Kubernetes limitation: some StatefulSet
+fields are immutable after creation, especially fields under
+`volumeClaimTemplates`. If Helm tries to patch one of those fields in place, the
+API server rejects the update and the sync fails.
+
+### Flow description
+
+1. Run `helmfile -e <environment> sync` and capture the output plus exit code.
+2. If the sync succeeds, print the output and exit normally.
+3. If the sync fails for a reason other than `field is immutable`, return the original failure unchanged.
+4. If the sync fails with an immutable-field error, scan the error output for allowlisted StatefulSet names.
+5. If no allowlisted StatefulSet is explicitly named in the error output, fail closed and delete nothing.
+6. If one or more allowlisted StatefulSets are named, delete only those StatefulSet objects with `kubectl delete statefulset ... --cascade=orphan`.
+7. Retry the same `helmfile -e <environment> sync`.
+8. On the retry, Helm recreates the missing StatefulSet object with the new spec while the existing pods and PVCs remain in place.
+
+### Why orphan-delete is used
+
+- `--cascade=orphan` deletes the StatefulSet object only.
+- Existing pods keep running instead of being torn down immediately.
+- Existing PVCs remain attached to the workload identity.
+- The retry can recreate the controller object without automatically touching unrelated healthy resources.
+
+### Safety guard
+
+The recovery path is intentionally narrow.
+
+- The script only considers StatefulSets listed in its internal allowlist.
+- The script only orphan-deletes a StatefulSet if that exact name appears in the immutable-field error output.
+- If another resource fails, or a different StatefulSet such as `vector` fails, the wrapper exits with the original error and performs no deletion.
+
+### Flowchart
+
+```mermaid
+flowchart TD
+    A[Run helmfile -e env sync
+Capture output and exit code] --> B{Sync succeeded?}
+    B -->|Yes| C[Print output
+Exit 0]
+    B -->|No| D{Output contains
+field is immutable?}
+    D -->|No| E[Print original error
+Exit with original failure]
+    D -->|Yes| F[Find allowlisted StatefulSet names
+mentioned in the error output]
+    F --> G{Any allowlisted
+match found?}
+    G -->|No| H[Fail closed
+Delete nothing
+Exit with original failure]
+    G -->|Yes| I[Orphan-delete only matched StatefulSet objects
+Pods and PVCs stay in place]
+    I --> J[Retry helmfile -e env sync]
+    J --> K[Helm recreates StatefulSet object
+Workload resumes under new controller]
+```
+
+### Controller and workload effect
+
+```text
+Before orphan-delete:
+  StatefulSet ----owns----> Pods + PVCs
+
+After kubectl delete statefulset --cascade=orphan:
+  StatefulSet    removed
+  Pods           still running
+  PVCs           still present
+
+After retry sync:
+  Helm recreates StatefulSet object
+  Kubernetes re-associates the controller with the existing workload
+```
 
 ## Rollback
 

--- a/docs/corp-quickstart.md
+++ b/docs/corp-quickstart.md
@@ -88,82 +88,14 @@ download is required from the cluster.
 
 ## Helmfile sync retry flow
 
-`make corp-deploy`, `make corp-sync`, and `make homelab-sync` all call
-`./scripts/helmfile-sync.sh <environment>` instead of invoking `helmfile sync`
-directly.
+`make corp-deploy`, `make corp-sync`, and `make homelab-sync` all use
+`./scripts/helmfile-sync.sh <environment>` instead of `helmfile sync` directly.
+The wrapper auto-recovers from StatefulSet immutable field errors (e.g. PVC size
+or storageClassName changes on vmstorage) by orphan-deleting only allowlisted
+StatefulSets and retrying the sync. Pods and PVCs remain running throughout.
 
-The wrapper exists for one specific Kubernetes limitation: some StatefulSet
-fields are immutable after creation, especially fields under
-`volumeClaimTemplates`. If Helm tries to patch one of those fields in place, the
-API server rejects the update and the sync fails.
-
-### Flow description
-
-1. Run `helmfile -e <environment> sync` and capture the output plus exit code.
-2. If the sync succeeds, print the output and exit normally.
-3. If the sync fails for a reason other than `field is immutable`, return the original failure unchanged.
-4. If the sync fails with an immutable-field error, scan the error output for allowlisted StatefulSet names.
-5. If no allowlisted StatefulSet is explicitly named in the error output, fail closed and delete nothing.
-6. If one or more allowlisted StatefulSets are named, delete only those StatefulSet objects with `kubectl delete statefulset ... --cascade=orphan`.
-7. Retry the same `helmfile -e <environment> sync`.
-8. On the retry, Helm recreates the missing StatefulSet object with the new spec while the existing pods and PVCs remain in place.
-
-### Why orphan-delete is used
-
-- `--cascade=orphan` deletes the StatefulSet object only.
-- Existing pods keep running instead of being torn down immediately.
-- Existing PVCs remain attached to the workload identity.
-- The retry can recreate the controller object without automatically touching unrelated healthy resources.
-
-### Safety guard
-
-The recovery path is intentionally narrow.
-
-- The script only considers StatefulSets listed in its internal allowlist.
-- The script only orphan-deletes a StatefulSet if that exact name appears in the immutable-field error output.
-- If another resource fails, or a different StatefulSet such as `vector` fails, the wrapper exits with the original error and performs no deletion.
-
-### Flowchart
-
-```mermaid
-flowchart TD
-    A[Run helmfile -e env sync
-Capture output and exit code] --> B{Sync succeeded?}
-    B -->|Yes| C[Print output
-Exit 0]
-    B -->|No| D{Output contains
-field is immutable?}
-    D -->|No| E[Print original error
-Exit with original failure]
-    D -->|Yes| F[Find allowlisted StatefulSet names
-mentioned in the error output]
-    F --> G{Any allowlisted
-match found?}
-    G -->|No| H[Fail closed
-Delete nothing
-Exit with original failure]
-    G -->|Yes| I[Orphan-delete only matched StatefulSet objects
-Pods and PVCs stay in place]
-    I --> J[Retry helmfile -e env sync]
-    J --> K[Helm recreates StatefulSet object
-Workload resumes under new controller]
-```
-
-### Controller and workload effect
-
-```text
-Before orphan-delete:
-  StatefulSet ----owns----> Pods + PVCs
-
-After kubectl delete statefulset --cascade=orphan:
-  StatefulSet    removed
-  Pods           still running
-  PVCs           still present
-
-After retry sync:
-  Helm recreates StatefulSet object
-  Kubernetes re-associates the controller with the existing workload
-```
+See [`scripts/helmfile-sync.sh`](../scripts/helmfile-sync.sh) for the full
+implementation, allowlist, and safety guards.
 
 ## Rollback
 

--- a/docs/helmfile-sync.md
+++ b/docs/helmfile-sync.md
@@ -1,0 +1,92 @@
+# Helmfile Sync Retry Flow
+
+> Detailed description of [`scripts/helmfile-sync.sh`](../scripts/helmfile-sync.sh) — the wrapper used by `make corp-deploy`, `make corp-sync`, and `make homelab-sync`.
+
+## Why this wrapper exists
+
+Kubernetes StatefulSet `spec.volumeClaimTemplates` fields are immutable after creation (PVC size, storageClassName, accessModes). When Helm tries to update these fields in place, the API server rejects the change and `helmfile sync` fails.
+
+The wrapper detects this specific failure, orphan-deletes only allowlisted StatefulSets (pods and PVCs keep running), and retries the sync so Helm can recreate the StatefulSet object with the new spec.
+
+## Flow description
+
+1. Run `helmfile -e <environment> sync` and capture the output plus exit code.
+2. If the sync succeeds, print the output and exit normally.
+3. If the sync fails for a reason other than `field is immutable`, return the original failure unchanged.
+4. If the sync fails with an immutable-field error, scan the error output for allowlisted StatefulSet names.
+5. If no allowlisted StatefulSet is explicitly named in the error output, fail closed and delete nothing.
+6. If one or more allowlisted StatefulSets are named, delete only those StatefulSet objects with `kubectl delete statefulset ... --cascade=orphan`.
+7. Retry the same `helmfile -e <environment> sync`.
+8. On the retry, Helm recreates the missing StatefulSet object with the new spec while the existing pods and PVCs remain in place.
+
+## Why orphan-delete is used
+
+- `--cascade=orphan` deletes the StatefulSet object only.
+- Existing pods keep running instead of being torn down immediately.
+- Existing PVCs remain attached to the workload identity.
+- The retry can recreate the controller object without automatically touching unrelated healthy resources.
+
+## Safety guards
+
+The recovery path is intentionally narrow.
+
+- The script only considers StatefulSets listed in its internal allowlist (currently only `vmstorage`).
+- The script only orphan-deletes a StatefulSet if that exact name appears in the immutable-field error output.
+- If another resource fails, or a non-allowlisted StatefulSet such as `vector` fails, the wrapper exits with the original error and performs no deletion.
+- ClickHouse StatefulSets are operator-managed and excluded — immutable field changes on ClickHouse require `ClickHouseInstallation` CR recreation through the operator.
+
+## Flowchart
+
+```mermaid
+flowchart TD
+    A[Run helmfile -e env sync
+Capture output and exit code] --> B{Sync succeeded?}
+    B -->|Yes| C[Print output
+Exit 0]
+    B -->|No| D{Output contains
+field is immutable?}
+    D -->|No| E[Print original error
+Exit with original failure]
+    D -->|Yes| F[Find allowlisted StatefulSet names
+mentioned in the error output]
+    F --> G{Any allowlisted
+match found?}
+    G -->|No| H[Fail closed
+Delete nothing
+Exit with original failure]
+    G -->|Yes| I[Orphan-delete only matched StatefulSet objects
+Pods and PVCs stay in place]
+    I --> J[Retry helmfile -e env sync]
+    J --> K{Retry succeeded?}
+    K -->|Yes| L[Helm recreates StatefulSet object
+Workload resumes under new controller]
+    K -->|No| M[Print retry failure
+Manual intervention required]
+```
+
+## Controller and workload effect
+
+```text
+Before orphan-delete:
+  StatefulSet ----owns----> Pods + PVCs
+
+After kubectl delete statefulset --cascade=orphan:
+  StatefulSet    removed
+  Pods           still running
+  PVCs           still present
+
+After retry sync:
+  Helm recreates StatefulSet object
+  Kubernetes re-associates the controller with the existing workload
+```
+
+## Other sync blockers (not handled by this wrapper)
+
+| Category | Risk | Notes |
+|---|---|---|
+| ClickHouse StatefulSet (operator-managed) | Critical | Requires CHI CR recreation, not orphan-delete |
+| Service `spec.type` change | Medium | ClusterIP→LoadBalancer needs delete+recreate |
+| CRD not ready (ClickHouse) | High | Already mitigated by `needs:` in helmfile |
+| Storage provisioning (no StorageClass) | High | Already mitigated by `corp-ensure-sc` target |
+| Image pull failure (corp airgap) | High | Mitigated by `corp-sync-images.sh` pre-step |
+| Config syntax errors | High | Caught by `helmfile lint` / `make lint` |

--- a/scripts/helmfile-sync.sh
+++ b/scripts/helmfile-sync.sh
@@ -33,12 +33,15 @@ find_affected_statefulsets() {
 
   for entry in "${MANAGED_STATEFULSETS[@]}"; do
     sts="${entry#*/}"
+    # K8s API errors quote the resource name: StatefulSet.apps "name" is invalid
     if [[ "$output" == *"\"$sts\""* ]]; then
       matched+=("$entry")
     fi
   done
 
-  printf '%s\n' "${matched[@]}"
+  if [ ${#matched[@]} -gt 0 ]; then
+    printf '%s\n' "${matched[@]}"
+  fi
 }
 
 echo "=== gpu-mon helmfile sync ($ENV) ==="
@@ -93,5 +96,8 @@ for entry in "${AFFECTED_STATEFULSETS[@]}"; do
 done
 
 echo "[retry] Re-running helmfile sync..."
-helmfile -e "$ENV" sync
+if ! helmfile -e "$ENV" sync; then
+  echo "[retry] Retry also failed. Manual intervention required."
+  exit 1
+fi
 echo "=== sync completed after StatefulSet recreation ==="

--- a/scripts/helmfile-sync.sh
+++ b/scripts/helmfile-sync.sh
@@ -88,9 +88,10 @@ echo "[retry] Orphan-deleting only the affected StatefulSets named in the error 
 for entry in "${AFFECTED_STATEFULSETS[@]}"; do
   ns="${entry%%/*}"
   sts="${entry#*/}"
-  if kubectl get statefulset "$sts" -n "$ns" &>/dev/null; then
-    echo "[retry]   Orphan-deleting $ns/$sts..."
-    kubectl delete statefulset "$sts" -n "$ns" --cascade=orphan
+  echo "[retry]   Orphan-deleting $ns/$sts..."
+  if ! kubectl delete statefulset "$sts" -n "$ns" --cascade=orphan 2>/dev/null; then
+    echo "[retry]   $ns/$sts not found — already deleted, skipping."
+  else
     echo "[retry]   $ns/$sts deleted — pods still running."
   fi
 done

--- a/scripts/helmfile-sync.sh
+++ b/scripts/helmfile-sync.sh
@@ -89,11 +89,17 @@ for entry in "${AFFECTED_STATEFULSETS[@]}"; do
   ns="${entry%%/*}"
   sts="${entry#*/}"
   echo "[retry]   Orphan-deleting $ns/$sts..."
-  if ! kubectl delete statefulset "$sts" -n "$ns" --cascade=orphan 2>/dev/null; then
-    echo "[retry]   $ns/$sts not found — already deleted, skipping."
-  else
+  DELETE_ERR=$(kubectl delete statefulset "$sts" -n "$ns" --cascade=orphan 2>&1) && {
     echo "[retry]   $ns/$sts deleted — pods still running."
-  fi
+  } || {
+    if echo "$DELETE_ERR" | grep -qi "not found"; then
+      echo "[retry]   $ns/$sts not found — already deleted, skipping."
+    else
+      echo "[retry]   Failed to delete $ns/$sts:" >&2
+      echo "$DELETE_ERR" >&2
+      exit 1
+    fi
+  }
 done
 
 echo "[retry] Re-running helmfile sync..."

--- a/scripts/helmfile-sync.sh
+++ b/scripts/helmfile-sync.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# helmfile-sync.sh — Helmfile sync wrapper with StatefulSet immutable field handling
+#
+# Kubernetes StatefulSets have immutable fields (volumeClaimTemplates: size,
+# storageClassName, accessModes). When Helm tries to update these, the API
+# server rejects the change and helmfile sync fails.
+#
+# This wrapper detects such failures, orphan-deletes the affected StatefulSets
+# (pods and PVCs keep running), and retries. The recreated StatefulSet adopts
+# the existing pods.
+#
+# Usage: ./scripts/helmfile-sync.sh <environment>
+#
+# Note: ClickHouse StatefulSets are operator-managed and excluded here.
+# Immutable field changes on ClickHouse require ClickHouseInstallation CR
+# recreation through the operator.
+
+set -euo pipefail
+
+ENV="${1:?Usage: $0 <environment>}"
+
+# Helm-managed StatefulSets that may hit immutable field errors.
+# Format: "namespace/statefulset-name"
+MANAGED_STATEFULSETS=(
+  "monitoring/victoriametrics-victoria-metrics-cluster-vmstorage"
+)
+
+echo "=== gpu-mon helmfile sync ($ENV) ==="
+
+# Attempt helmfile sync, capturing output and exit code separately.
+set +e
+OUTPUT=$(helmfile -e "$ENV" sync 2>&1)
+RC=$?
+set -e
+
+# Success — print output and exit.
+if [ $RC -eq 0 ]; then
+  echo "$OUTPUT"
+  echo "=== sync completed successfully ==="
+  exit 0
+fi
+
+# Check if the failure is due to immutable field errors.
+if ! echo "$OUTPUT" | grep -qi "field is immutable"; then
+  # Not an immutable field issue — surface the original error.
+  echo "$OUTPUT"
+  exit "$RC"
+fi
+
+echo "$OUTPUT"
+echo ""
+echo "[retry] Detected immutable field error in StatefulSet update."
+echo "[retry] Orphan-deleting affected StatefulSets (pods and PVCs preserved)..."
+
+for entry in "${MANAGED_STATEFULSETS[@]}"; do
+  ns="${entry%%/*}"
+  sts="${entry#*/}"
+  if kubectl get statefulset "$sts" -n "$ns" &>/dev/null; then
+    echo "[retry]   Orphan-deleting $ns/$sts..."
+    kubectl delete statefulset "$sts" -n "$ns" --cascade=orphan
+    echo "[retry]   $ns/$sts deleted — pods still running."
+  fi
+done
+
+echo "[retry] Re-running helmfile sync..."
+helmfile -e "$ENV" sync
+echo "=== sync completed after StatefulSet recreation ==="

--- a/scripts/helmfile-sync.sh
+++ b/scripts/helmfile-sync.sh
@@ -25,6 +25,22 @@ MANAGED_STATEFULSETS=(
   "monitoring/victoriametrics-victoria-metrics-cluster-vmstorage"
 )
 
+find_affected_statefulsets() {
+  local output="$1"
+  local matched=()
+  local entry
+  local sts
+
+  for entry in "${MANAGED_STATEFULSETS[@]}"; do
+    sts="${entry#*/}"
+    if [[ "$output" == *"\"$sts\""* ]]; then
+      matched+=("$entry")
+    fi
+  done
+
+  printf '%s\n' "${matched[@]}"
+}
+
 echo "=== gpu-mon helmfile sync ($ENV) ==="
 
 # Attempt helmfile sync, capturing output and exit code separately.
@@ -50,9 +66,23 @@ fi
 echo "$OUTPUT"
 echo ""
 echo "[retry] Detected immutable field error in StatefulSet update."
-echo "[retry] Orphan-deleting affected StatefulSets (pods and PVCs preserved)..."
 
-for entry in "${MANAGED_STATEFULSETS[@]}"; do
+AFFECTED_STATEFULSETS=()
+while IFS= read -r entry; do
+  if [ -n "$entry" ]; then
+    AFFECTED_STATEFULSETS+=("$entry")
+  fi
+done < <(find_affected_statefulsets "$OUTPUT")
+
+if [ ${#AFFECTED_STATEFULSETS[@]} -eq 0 ]; then
+  echo "[retry] No allowlisted StatefulSet was named in the error output."
+  echo "[retry] Refusing to orphan-delete healthy resources; inspect the sync failure above."
+  exit "$RC"
+fi
+
+echo "[retry] Orphan-deleting only the affected StatefulSets named in the error output..."
+
+for entry in "${AFFECTED_STATEFULSETS[@]}"; do
   ns="${entry%%/*}"
   sts="${entry#*/}"
   if kubectl get statefulset "$sts" -n "$ns" &>/dev/null; then


### PR DESCRIPTION
## Summary
- Add `scripts/helmfile-sync.sh` wrapper that detects StatefulSet immutable field errors (PVC size, storageClassName, accessModes), orphan-deletes the affected StatefulSet (pods and PVCs preserved), and retries `helmfile sync`
- Update `homelab-sync`, `corp-sync`, and `corp-deploy` Makefile targets to use the wrapper
- Scoped to Helm-managed StatefulSets only (vmstorage); ClickHouse StatefulSets are operator-managed and excluded

## Context
Kubernetes StatefulSet `spec.volumeClaimTemplates` fields are immutable. When Helm values change PVC size or storageClassName, `helmfile sync` fails because `helm upgrade` cannot update these fields in-place. The `--cascade=orphan` delete pattern removes the StatefulSet controller object while keeping pods running, allowing Helm to recreate it with the new spec.

### Other sync blockers identified (not in scope for this PR)

| Category | Risk | Notes |
|---|---|---|
| ClickHouse StatefulSet (operator-managed) | Critical | Requires CHI CR recreation, not orphan-delete |
| Service `spec.type` change | Medium | ClusterIP→LoadBalancer needs delete+recreate |
| CRD not ready (ClickHouse) | High | Already mitigated by `needs:` in helmfile |
| Storage provisioning (no StorageClass) | High | Already mitigated by `corp-ensure-sc` target |
| Image pull failure (corp airgap) | High | Mitigated by `corp-sync-images.sh` pre-step |
| Config syntax errors | High | Caught by `helmfile lint` / `make lint` |

## Test plan
- [ ] `make homelab-sync` with no immutable field changes — should pass through normally
- [ ] `make homelab-sync` after changing `vmstorage.persistentVolume.size` — should auto-retry after orphan-delete
- [ ] `make corp-deploy` — should use wrapper for the sync step
- [ ] Fresh install (no existing StatefulSet) — should skip orphan-delete and sync normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)