### PR TITLE
fix: detect forbidden StatefulSet spec updates during sync

### DIFF
--- a/docs/helmfile-sync.md
+++ b/docs/helmfile-sync.md
@@ -12,8 +12,8 @@ The wrapper detects this specific failure, orphan-deletes only allowlisted State
 
 1. Run `helmfile -e <environment> sync` and capture the output plus exit code.
 2. If the sync succeeds, print the output and exit normally.
-3. If the sync fails for a reason other than `field is immutable`, return the original failure unchanged.
-4. If the sync fails with an immutable-field error, scan the error output for allowlisted StatefulSet names.
+3. If the sync fails for a reason other than an immutable StatefulSet update error, return the original failure unchanged.
+4. If the sync fails with an immutable StatefulSet update error, scan the error output for allowlisted StatefulSet names.
 5. If no allowlisted StatefulSet is explicitly named in the error output, fail closed and delete nothing.
 6. If one or more allowlisted StatefulSets are named, delete only those StatefulSet objects with `kubectl delete statefulset ... --cascade=orphan`.
 7. Retry the same `helmfile -e <environment> sync`.
@@ -43,8 +43,8 @@ flowchart TD
 Capture output and exit code] --> B{Sync succeeded?}
     B -->|Yes| C[Print output
 Exit 0]
-    B -->|No| D{Output contains
-field is immutable?}
+    B -->|No| D{Output matches immutable
+StatefulSet error?}
     D -->|No| E[Print original error
 Exit with original failure]
     D -->|Yes| F[Find allowlisted StatefulSet names

--- a/scripts/helmfile-sync.sh
+++ b/scripts/helmfile-sync.sh
@@ -44,6 +44,12 @@ find_affected_statefulsets() {
   fi
 }
 
+has_statefulset_immutable_error() {
+  local output="$1"
+
+  grep -Eqi     'field is immutable|updates to statefulset spec for fields other than'     <<<"$output"
+}
+
 echo "=== gpu-mon helmfile sync ($ENV) ==="
 
 # Attempt helmfile sync, capturing output and exit code separately.
@@ -59,9 +65,9 @@ if [ $RC -eq 0 ]; then
   exit 0
 fi
 
-# Check if the failure is due to immutable field errors.
-if ! echo "$OUTPUT" | grep -qi "field is immutable"; then
-  # Not an immutable field issue — surface the original error.
+# Check if the failure is due to an immutable StatefulSet update.
+if ! has_statefulset_immutable_error "$OUTPUT"; then
+  # Not an immutable StatefulSet issue — surface the original error.
   echo "$OUTPUT"
   exit "$RC"
 fi

--- a/scripts/helmfile-sync.sh
+++ b/scripts/helmfile-sync.sh
@@ -47,7 +47,7 @@ find_affected_statefulsets() {
 has_statefulset_immutable_error() {
   local output="$1"
 
-  grep -Eqi     'field is immutable|updates to statefulset spec for fields other than'     <<<"$output"
+  grep -Eqi 'field is immutable|updates to statefulset spec for fields other than' <<<"$output"
 }
 
 echo "=== gpu-mon helmfile sync ($ENV) ==="


### PR DESCRIPTION
## Summary
- detect both common immutable StatefulSet upgrade error signatures during helmfile sync
- keep the existing allowlist/name match so only the intended StatefulSet is eligible for orphan-delete
- update the detailed retry-flow doc to reflect the broader matcher wording

## Validation
- `bash -n scripts/helmfile-sync.sh`
- `git diff --check -- scripts/helmfile-sync.sh docs/helmfile-sync.md`
- `bash -c 'source <(sed -n "22,52p" scripts/helmfile-sync.sh); has_statefulset_immutable_error $'Error: UPGRADE FAILED: cannot patch \\\"victoriametrics-victoria-metrics-cluster-vmstorage\\\" with kind StatefulSet: StatefulSet.apps \\\"victoriametrics-victoria-metrics-cluster-vmstorage\\\" is invalid: spec: Forbidden: updates to statefulset spec for fields other than replicas''`\n- `bash -c 'source <(sed -n "22,52p" scripts/helmfile-sync.sh); find_affected_statefulsets $'Error: UPGRADE FAILED: cannot patch \\\"victoriametrics-victoria-metrics-cluster-vmstorage\\\" with kind StatefulSet: StatefulSet.apps \\\"victoriametrics-victoria-metrics-cluster-vmstorage\\\" is invalid: spec: Forbidden: updates to statefulset spec for fields other than replicas''`