### PR TITLE
fix: disable schema validation for corp StorageClass apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ corp-ensure-sc: corp-preflight ## Ensure required StorageClass exists for corp P
 		echo "StorageClass spectrum-scale already exists, skipping"; \
 	elif [ -f environments/corp/storageclass.yaml ]; then \
 		echo "Creating StorageClass spectrum-scale..."; \
-		kubectl apply -f environments/corp/storageclass.yaml; \
+		kubectl apply --validate=false -f environments/corp/storageclass.yaml; \
 	else \
 		echo "ERROR: StorageClass spectrum-scale not found in cluster and environments/corp/storageclass.yaml is missing." >&2; \
 		echo "  Copy environments/corp.example/storageclass.yaml.example → environments/corp/storageclass.yaml and fill in values." >&2; \

--- a/docs/corp-deployment-strategy.md
+++ b/docs/corp-deployment-strategy.md
@@ -240,7 +240,7 @@ corp-ensure-sc: corp-preflight ## Ensure required StorageClass exists for corp P
 		echo "StorageClass spectrum-scale already exists, skipping"; \
 	elif [ -f environments/corp/storageclass.yaml ]; then \
 		echo "Creating StorageClass spectrum-scale..."; \
-		kubectl apply -f environments/corp/storageclass.yaml; \
+		kubectl apply --validate=false -f environments/corp/storageclass.yaml; \
 	else \
 		echo "ERROR: StorageClass spectrum-scale not found and manifest missing"; \
 		exit 1; \

--- a/docs/corp-deployment-strategy.md
+++ b/docs/corp-deployment-strategy.md
@@ -247,13 +247,17 @@ corp-ensure-sc: corp-preflight ## Ensure required StorageClass exists for corp P
 	fi
 
 corp-sync: corp-ensure-sc ## Deploy to corp K8s cluster (helmfile only, no image sync)
-	helmfile -e corp sync
+	./scripts/helmfile-sync.sh corp
 
 corp-deploy: corp-ensure-sc ## Sync images + deploy to corp cluster (one-touch)
 	./scripts/corp-sync-images.sh $(CORP_REGISTRY)
 	helmfile -e corp diff
-	helmfile -e corp sync
+	./scripts/helmfile-sync.sh corp
 ```
+
+`corp-preflight` now also prints the current `kubectl` context/server and warns
+when the kubeconfig appears to use a Rancher proxy endpoint, so operators can
+see which cluster `kubectl` will target before deploy-time mutations run.
 
 ### Daily Workflow
 

--- a/docs/corp-quickstart.md
+++ b/docs/corp-quickstart.md
@@ -75,7 +75,7 @@ To build locally (e.g. for testing): `make build-grafana-plugins`
 
 ## What `make corp-deploy` does
 
-1. Pre-flight validation (`validate-corp-setup.sh`) checks symlinks and required files
+1. Pre-flight validation (`validate-corp-setup.sh`) checks symlinks and required files, prints the current `kubectl` context/server, and warns if the kubeconfig appears to go through a Rancher proxy endpoint
 2. StorageClass `spectrum-scale` is created if absent in the cluster (skipped if it already exists; fails if the manifest file is missing)
 3. `corp-sync-images.sh` reads `versions.yaml`, pulls images from GHCR/DockerHub, and pushes them to the corp registry (includes the `grafana-plugins` carrier image when listed under `custom_images`)
 4. `helmfile -e corp diff` previews changes

--- a/environments/corp.example/README.md
+++ b/environments/corp.example/README.md
@@ -37,7 +37,7 @@ VictoriaMetrics and ClickHouse PVCs. It is **not** managed by Helmfile.
 - If the StorageClass already exists in the cluster, it is **skipped**
   (safe when the SC is managed externally, e.g. by the storage team).
 - If it is absent and `environments/corp/storageclass.yaml` exists on disk,
-  it is created via `kubectl apply`.
+  it is created via `kubectl apply --validate=false` to avoid blocking on OpenAPI schema fetch timeouts from the cluster API.
 - To update an existing SC, delete it first then re-run:
   `kubectl delete sc spectrum-scale && make corp-deploy`
 

--- a/environments/corp.example/storageclass.yaml.example
+++ b/environments/corp.example/storageclass.yaml.example
@@ -5,7 +5,7 @@
 # Primary path: `make corp-deploy` or `make corp-sync` will apply this
 # automatically if `spectrum-scale` does not already exist in the cluster.
 # Manual path (optional):
-#   kubectl apply -f environments/corp/storageclass.yaml
+#   kubectl apply --validate=false -f environments/corp/storageclass.yaml
 
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/scripts/validate-corp-setup.sh
+++ b/scripts/validate-corp-setup.sh
@@ -63,6 +63,28 @@ elif [ -z "$(ls -A "$TARGETS_DIR" 2>/dev/null)" ]; then
   errors=1
 fi
 
+# 4. Print kubectl context/server info and warn for Rancher-style proxy endpoints.
+if command -v kubectl >/dev/null 2>&1; then
+  CURRENT_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
+  if [ -n "$CURRENT_CONTEXT" ]; then
+    CLUSTER_SERVER="$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null || true)"
+    echo "INFO: kubectl current-context: $CURRENT_CONTEXT"
+    if [ -n "$CLUSTER_SERVER" ]; then
+      echo "INFO: kubectl cluster server: $CLUSTER_SERVER"
+      if [[ "$CLUSTER_SERVER" == *"/k8s/clusters/"* ]] || [[ "$CLUSTER_SERVER" == *"rancher"* ]]; then
+        echo "WARN: kubeconfig appears to target a Rancher proxy/API endpoint."
+        echo "WARN: Client-side OpenAPI/schema fetches can time out through Rancher; corp StorageClass creation uses kubectl apply --validate=false for that reason."
+      fi
+    else
+      echo "WARN: Unable to determine kubectl cluster server from the current kubeconfig."
+    fi
+  else
+    echo "WARN: kubectl current-context is not set. Corp deploy will use whichever kubeconfig/context kubectl resolves at runtime."
+  fi
+else
+  echo "WARN: kubectl is not installed or not in PATH. Corp deploy commands require kubectl."
+fi
+
 if [ "$errors" -ne 0 ]; then
   echo ""
   echo "Corp pre-flight check FAILED. Fix the issues above before deploying."


### PR DESCRIPTION
## Summary
- use `kubectl apply --validate=false` when `corp-ensure-sc` creates `spectrum-scale`
- keep the same create-if-absent behavior while avoiding OpenAPI fetch timeouts from the cluster API
- update the corp deployment docs and example README/manual command to match the runtime behavior

## Why
`make corp-deploy` can fail before Helmfile runs when `kubectl apply -f environments/corp/storageclass.yaml` blocks on downloading the cluster OpenAPI schema. In that case the manifest itself may be valid, but the client-side schema fetch times out and aborts the deploy.

## Validation
- `git diff --check -- Makefile docs/corp-deployment-strategy.md environments/corp.example/README.md environments/corp.example/storageclass.yaml.example`