### PR TITLE
fix: use extraInitContainers for Grafana plugin init in airgap mode

### DIFF
--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -89,7 +89,7 @@ releases:
       - environments/{{ .Environment.Name }}/grafana.yaml
     {{ if .Values.grafana_plugins_init }}
       - plugins: []
-        initContainers:
+        extraInitContainers:
           - name: install-plugins
             image: "{{ .Values.image_registry }}/grafana-plugins:{{ index .Values.custom_images "grafana-plugins" }}"
             command: ["sh", "-c", "cp -r /plugins/* /grafana-plugins/"]


### PR DESCRIPTION
## Summary
- Fix Grafana pod crash in airgap environments caused by using the wrong Helm values key for init containers
- The Grafana chart (v10.5.15) expects `extraInitContainers`, not `initContainers` — the wrong key was silently ignored, so the plugin carrier image was never mounted and Grafana fell back to downloading plugins online

## Test plan
- [ ] Deploy with `grafana_plugins_init: true` in an airgap environment and verify the `install-plugins` init container runs
- [ ] Confirm Grafana pod starts successfully with plugins loaded from the carrier image
- [ ] Verify `helm template` output includes the init container under `initContainers:` in the pod spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)