### PR TITLE
fix: let vmagent-central chart create file-sd ConfigMap from values

### DIFF
--- a/charts/vmagent-central/templates/configmap-filesd.yaml
+++ b/charts/vmagent-central/templates/configmap-filesd.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.fileSD.enabled }}
+{{- if and .Values.fileSD.enabled .Values.fileSD.data }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +7,5 @@ metadata:
   labels:
     {{- include "vmagent-central.labels" . | nindent 4 }}
 data:
-{{- if .Values.fileSD.data }}
-{{- toYaml .Values.fileSD.data | nindent 2 }}
-{{- end }}
+  {{- toYaml .Values.fileSD.data | nindent 2 }}
 {{- end }}

--- a/charts/vmagent-central/templates/configmap-filesd.yaml
+++ b/charts/vmagent-central/templates/configmap-filesd.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.fileSD.enabled .Values.fileSD.data }}
+{{- if .Values.fileSD.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "vmagent-central.labels" . | nindent 4 }}
 data:
-  {{- range $key, $val := .Values.fileSD.data }}
-  {{ $key }}: {{ $val | quote }}
-  {{- end }}
+{{- if .Values.fileSD.data }}
+{{- toYaml .Values.fileSD.data | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/vmagent-central/templates/configmap-filesd.yaml
+++ b/charts/vmagent-central/templates/configmap-filesd.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.fileSD.enabled .Values.fileSD.data }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vmagent-central.fullname" . }}-file-sd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vmagent-central.labels" . | nindent 4 }}
+data:
+  {{- range $key, $val := .Values.fileSD.data }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/vmagent-central/templates/deployment.yaml
+++ b/charts/vmagent-central/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/vmagent
-            {{- if .Values.fileSD.enabled }}
+            {{- if and .Values.fileSD.enabled .Values.fileSD.data }}
             - name: file-sd
               mountPath: /etc/vmagent/sd
             {{- end }}
@@ -59,7 +59,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "vmagent-central.fullname" . }}-config
-        {{- if .Values.fileSD.enabled }}
+        {{- if and .Values.fileSD.enabled .Values.fileSD.data }}
         - name: file-sd
           configMap:
             name: {{ include "vmagent-central.fullname" . }}-file-sd

--- a/charts/vmagent-central/templates/deployment.yaml
+++ b/charts/vmagent-central/templates/deployment.yaml
@@ -62,5 +62,5 @@ spec:
         {{- if .Values.fileSD.enabled }}
         - name: file-sd
           configMap:
-            name: {{ .Values.fileSD.configMapName }}
+            name: {{ include "vmagent-central.fullname" . }}-file-sd
         {{- end }}

--- a/charts/vmagent-central/tests/deployment_test.yaml
+++ b/charts/vmagent-central/tests/deployment_test.yaml
@@ -92,16 +92,34 @@ tests:
           content:
             name: file-sd
 
-  - it: mounts file-sd volume when fileSD enabled
+  - it: mounts file-sd volume when fileSD enabled with data
     documentIndex: 0
     set:
       fileSD:
         enabled: true
-        configMapName: my-file-sd
+        data:
+          targets.json: '[{"targets":["node:9400"]}]'
     asserts:
       - contains:
           path: spec.template.spec.volumes
           content:
             name: file-sd
             configMap:
-              name: my-file-sd
+              name: RELEASE-NAME-vmagent-central-file-sd
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: file-sd
+            mountPath: /etc/vmagent/sd
+
+  - it: does not mount file-sd volume when fileSD enabled but data empty
+    documentIndex: 0
+    set:
+      fileSD:
+        enabled: true
+        data: {}
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: file-sd

--- a/charts/vmagent-central/values.yaml
+++ b/charts/vmagent-central/values.yaml
@@ -15,11 +15,13 @@ extraArgs: []
 # Full vmagent scrape configuration (merged by environment values)
 scrapeConfig: {}
 
-# File SD config map: Ansible-managed JSON target files
-# Keys are mounted as /etc/vmagent/sd/<key>
+# File SD: target JSON files mounted as /etc/vmagent/sd/<key>
+# Each key becomes a file; value is the JSON content (Prometheus file_sd format).
 fileSD:
   enabled: false
-  configMapName: vmagent-file-sd
+  data: {}
+  #   baremetal-gpu-nodes.json: |
+  #     [{"targets":["node-01:9400"],"labels":{"platform":"baremetal"}}]
 
 resources:
   requests:

--- a/environments/corp.example/vmagent.yaml.example
+++ b/environments/corp.example/vmagent.yaml.example
@@ -6,9 +6,10 @@ replicaCount: 2   # HA pair
 remoteWrite:
   - url: "http://vminsert-victoriametrics.monitoring.svc:8480/insert/0/prometheus/"
 
+# Target data (fileSD.data) is auto-injected by helmfile from targets/*.json.
+# To update targets, edit the JSON files in environments/corp/targets/.
 fileSD:
   enabled: true
-  configMapName: vmagent-file-sd
 
 extraArgs:
   - "-promscrape.fileSDCheckInterval=60s"

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -62,7 +62,7 @@ releases:
       {{- range (exec "sh" (list "-c" (printf "ls %s/*.json 2>/dev/null | while read f; do basename \"$f\"; done" $targetsDir)) | trim | splitList "\n") }}
       {{- if ne . "" }}
             {{ . }}: |
-{{ exec "sh" (list "-c" (printf "cat %s/%s" $targetsDir .)) | indent 14 }}
+{{ exec "sh" (list "-c" (printf "cat '%s/%s'" $targetsDir .)) | indent 14 }}
       {{- end }}
       {{- end }}
     {{- end }}

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -55,6 +55,17 @@ releases:
     chart: charts/vmagent-central
     values:
       - environments/{{ .Environment.Name }}/vmagent.yaml
+    {{- $targetsDir := printf "environments/%s/targets" .Environment.Name }}
+    {{- if eq (exec "sh" (list "-c" (printf "test -d %s && echo true || echo false" $targetsDir)) | trim) "true" }}
+      - fileSD:
+          data:
+      {{- range (exec "sh" (list "-c" (printf "ls %s/*.json 2>/dev/null | while read f; do basename \"$f\"; done" $targetsDir)) | trim | splitList "\n") }}
+      {{- if ne . "" }}
+            {{ . }}: |
+{{ exec "sh" (list "-c" (printf "cat %s/%s" $targetsDir .)) | indent 14 }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
 
   # ─── ClickHouse Operator ──────────────────────────────────────────────────
   - name: clickhouse-operator

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -62,7 +62,7 @@ releases:
       {{- range (exec "sh" (list "-c" (printf "ls %s/*.json 2>/dev/null | while read f; do basename \"$f\"; done" $targetsDir)) | trim | splitList "\n") }}
       {{- if ne . "" }}
             {{ . }}: |
-{{ exec "sh" (list "-c" (printf "cat '%s/%s'" $targetsDir .)) | indent 14 }}
+{{ exec "sh" (list "-c" (printf "cat \"%s/%s\"" $targetsDir .)) | indent 14 }}
       {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
## Summary
- Add a ConfigMap template to the vmagent-central chart that renders file-sd target data from `fileSD.data` values
- Auto-inject target JSON files from `environments/<env>/targets/` via helmfile `exec` — no manual steps
- Remove `fileSD.configMapName` — the chart now owns the ConfigMap lifecycle

## Root cause
The chart Deployment referenced a ConfigMap `vmagent-file-sd` (via `fileSD.configMapName`), but nothing in the deploy pipeline ever created it. Result: `FailedMount` on every corp vmagent-central pod.

## How it works now
```
environments/corp/targets/*.json   (operators edit these)
         │
         ▼
helmfile.yaml.gotmpl  ──(exec cat)──►  fileSD.data values
         │
         ▼
chart configmap-filesd.yaml  ──►  ConfigMap (Helm-managed)
         │
         ▼
deployment.yaml  ──►  volume mount at /etc/vmagent/sd/
```

Operator workflow: edit target JSON files in `targets/`, run `helmfile sync`. One directory, one command.

## Test plan
- [x] `helmfile -e corp template -l name=vmagent-central` — ConfigMap contains all 3 target files
- [x] `helmfile -e homelab template -l name=vmagent-central` — no file-sd resources (no targets/ dir)
- [ ] Deploy to corp cluster and verify vmagent pod starts without FailedMount

🤖 Generated with [Claude Code](https://claude.com/claude-code)