### PR TITLE
feat: add ClickHouse Keeper chart for multi-replica support

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -159,3 +159,6 @@ jobs:
 
       - name: Run helm unit tests — metadata-collector
         run: helm unittest charts/metadata-collector
+
+      - name: Run helm unit tests — clickhouse-keeper
+        run: helm unittest charts/clickhouse-keeper

--- a/charts/clickhouse-cluster/templates/clickhouseinstallation.yaml
+++ b/charts/clickhouse-cluster/templates/clickhouseinstallation.yaml
@@ -1,3 +1,16 @@
+{{- /*
+  Preflight guard: ReplicatedMergeTree (replicasCount > 1) needs a working
+  ClickHouse Keeper / ZooKeeper endpoint. Fail the render (deploy-time) rather
+  than let a replicated cluster come up with no zookeeper block and silently go
+  read-only. The zookeeper block below is only emitted when keeper coordination
+  is both enabled and has nodes, so an enabled-but-empty config (e.g. a
+  single-replica opt-in test) renders cleanly without a malformed block.
+*/ -}}
+{{- if gt (int .Values.clickhouse.cluster.layout.replicasCount) 1 }}
+  {{- if or (not .Values.keeper.enabled) (not .Values.keeper.nodes) }}
+    {{- fail "clickhouse.cluster.layout.replicasCount > 1 requires keeper coordination: set clickhouse_keeper.enabled=true (Helmfile) / keeper.enabled=true (chart) and populate keeper.nodes in this environment's clickhouse.yaml." }}
+  {{- end }}
+{{- end }}
 apiVersion: clickhouse.altinity.com/v1
 kind: ClickHouseInstallation
 metadata:
@@ -10,7 +23,7 @@ spec:
         layout:
           shardsCount: {{ .Values.clickhouse.cluster.layout.shardsCount }}
           replicasCount: {{ .Values.clickhouse.cluster.layout.replicasCount }}
-    {{- if .Values.keeper.enabled }}
+    {{- if and .Values.keeper.enabled .Values.keeper.nodes }}
     zookeeper:
       nodes:
         {{- range .Values.keeper.nodes }}

--- a/charts/clickhouse-cluster/templates/clickhouseinstallation.yaml
+++ b/charts/clickhouse-cluster/templates/clickhouseinstallation.yaml
@@ -10,6 +10,14 @@ spec:
         layout:
           shardsCount: {{ .Values.clickhouse.cluster.layout.shardsCount }}
           replicasCount: {{ .Values.clickhouse.cluster.layout.replicasCount }}
+    {{- if .Values.keeper.enabled }}
+    zookeeper:
+      nodes:
+        {{- range .Values.keeper.nodes }}
+        - host: {{ .host }}
+          port: {{ .port }}
+        {{- end }}
+    {{- end }}
     settings:
       max_connections: "4096"
       keep_alive_timeout: "3"

--- a/charts/clickhouse-cluster/values.yaml
+++ b/charts/clickhouse-cluster/values.yaml
@@ -19,3 +19,16 @@ clickhouse:
 schema_init:
   enabled: true
   image: clickhouse/clickhouse-client:24.8
+
+# keeper: set enabled=true and list nodes when clickhouse-keeper is deployed
+# Required for replicasCount > 1
+keeper:
+  enabled: false
+  nodes: []
+  # nodes:
+  #   - host: clickhouse-keeper-0.clickhouse-keeper-headless.clickhouse.svc
+  #     port: 9181
+  #   - host: clickhouse-keeper-1.clickhouse-keeper-headless.clickhouse.svc
+  #     port: 9181
+  #   - host: clickhouse-keeper-2.clickhouse-keeper-headless.clickhouse.svc
+  #     port: 9181

--- a/charts/clickhouse-keeper/Chart.yaml
+++ b/charts/clickhouse-keeper/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: clickhouse-keeper
+description: ClickHouse Keeper — ZooKeeper-compatible coordination service for ClickHouse replication
+type: application
+version: 0.1.0
+appVersion: "24.8"

--- a/charts/clickhouse-keeper/templates/_helpers.tpl
+++ b/charts/clickhouse-keeper/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{- define "clickhouse-keeper.fullname" -}}
+clickhouse-keeper
+{{- end }}
+
+{{- define "clickhouse-keeper.headlessServiceName" -}}
+clickhouse-keeper-headless
+{{- end }}
+
+{{- define "clickhouse-keeper.labels" -}}
+app.kubernetes.io/name: clickhouse-keeper
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "clickhouse-keeper.selectorLabels" -}}
+app.kubernetes.io/name: clickhouse-keeper
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/clickhouse-keeper/templates/configmap.yaml
+++ b/charts/clickhouse-keeper/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
 data:
   keeper_config.xml: |
     <clickhouse>
+        <!-- Bind to all interfaces so peers (raft) and ClickHouse (client) can connect.
+             Without this, keeper listens on localhost only and the raft quorum never forms. -->
+        <listen_host>0.0.0.0</listen_host>
         <keeper_server>
             <tcp_port>{{ .Values.ports.client }}</tcp_port>
             <server_id>__SERVER_ID__</server_id>

--- a/charts/clickhouse-keeper/templates/configmap.yaml
+++ b/charts/clickhouse-keeper/templates/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clickhouse-keeper.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse-keeper.labels" . | nindent 4 }}
+data:
+  keeper_config.xml: |
+    <clickhouse>
+        <keeper_server>
+            <tcp_port>{{ .Values.ports.client }}</tcp_port>
+            <server_id>__SERVER_ID__</server_id>
+            <log_storage_path>/var/lib/clickhouse-keeper/log</log_storage_path>
+            <snapshot_storage_path>/var/lib/clickhouse-keeper/snapshots</snapshot_storage_path>
+            <coordination_settings>
+                <operation_timeout_ms>10000</operation_timeout_ms>
+                <session_timeout_ms>30000</session_timeout_ms>
+                <raft_logs_level>warning</raft_logs_level>
+            </coordination_settings>
+            <raft_configuration>
+              {{- range $i, $e := until (.Values.replicaCount | int) }}
+                <server>
+                    <id>{{ add $i 1 }}</id>
+                    <hostname>{{ include "clickhouse-keeper.fullname" $ }}-{{ $i }}.{{ include "clickhouse-keeper.headlessServiceName" $ }}.{{ $.Release.Namespace }}.svc</hostname>
+                    <port>{{ $.Values.ports.raft }}</port>
+                </server>
+              {{- end }}
+            </raft_configuration>
+        </keeper_server>
+    </clickhouse>
+  entrypoint.sh: |
+    #!/bin/sh
+    set -e
+    ORDINAL="${HOSTNAME##*-}"
+    SERVER_ID=$((ORDINAL + 1))
+    sed "s/__SERVER_ID__/${SERVER_ID}/" /etc/clickhouse-keeper/keeper_config.xml \
+      > /tmp/keeper_config.xml
+    exec clickhouse-keeper --config /tmp/keeper_config.xml

--- a/charts/clickhouse-keeper/templates/service-headless.yaml
+++ b/charts/clickhouse-keeper/templates/service-headless.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "clickhouse-keeper.labels" . | nindent 4 }}
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     {{- include "clickhouse-keeper.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/clickhouse-keeper/templates/service-headless.yaml
+++ b/charts/clickhouse-keeper/templates/service-headless.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse-keeper.headlessServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse-keeper.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "clickhouse-keeper.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: client
+      port: {{ .Values.ports.client }}
+      targetPort: client
+    - name: raft
+      port: {{ .Values.ports.raft }}
+      targetPort: raft

--- a/charts/clickhouse-keeper/templates/service.yaml
+++ b/charts/clickhouse-keeper/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse-keeper.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse-keeper.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "clickhouse-keeper.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: client
+      port: {{ .Values.ports.client }}
+      targetPort: client

--- a/charts/clickhouse-keeper/templates/statefulset.yaml
+++ b/charts/clickhouse-keeper/templates/statefulset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "clickhouse-keeper.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse-keeper.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "clickhouse-keeper.headlessServiceName" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "clickhouse-keeper.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "clickhouse-keeper.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: clickhouse-keeper
+          image: {{ .Values.image }}
+          command: ["/bin/sh", "/etc/clickhouse-keeper/entrypoint.sh"]
+          ports:
+            - name: client
+              containerPort: {{ .Values.ports.client }}
+              protocol: TCP
+            - name: raft
+              containerPort: {{ .Values.ports.raft }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/clickhouse-keeper
+            - name: data
+              mountPath: /var/lib/clickhouse-keeper
+          readinessProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "clickhouse-keeper.fullname" . }}-config
+            defaultMode: 0755
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        {{- if .Values.storage.storageClassName }}
+        storageClassName: {{ .Values.storage.storageClassName }}
+        {{- end }}
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: {{ .Values.storage.size }}

--- a/charts/clickhouse-keeper/templates/statefulset.yaml
+++ b/charts/clickhouse-keeper/templates/statefulset.yaml
@@ -19,6 +19,22 @@ spec:
       labels:
         {{- include "clickhouse-keeper.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.podAntiAffinity }}
+      # Soft (preferred) anti-affinity: spread replicas across nodes when possible.
+      # Not "required", so 3 replicas still schedule on 1-2 node clusters.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    {{- include "clickhouse-keeper.selectorLabels" . | nindent 20 }}
+      {{- end }}
       containers:
         - name: clickhouse-keeper
           image: {{ .Values.image }}

--- a/charts/clickhouse-keeper/templates/statefulset.yaml
+++ b/charts/clickhouse-keeper/templates/statefulset.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   serviceName: {{ include "clickhouse-keeper.headlessServiceName" . }}
   replicas: {{ .Values.replicaCount }}
+  # Start all keeper pods at once so the raft quorum can form on first boot;
+  # OrderedReady can stall because each pod's readiness depends on its peers.
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       {{- include "clickhouse-keeper.selectorLabels" . | nindent 6 }}

--- a/charts/clickhouse-keeper/tests/configmap_test.yaml
+++ b/charts/clickhouse-keeper/tests/configmap_test.yaml
@@ -1,0 +1,54 @@
+suite: clickhouse-keeper configmap
+templates:
+  - templates/configmap.yaml
+
+tests:
+  - it: renders a ConfigMap with the keeper config and entrypoint
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - isNotNull:
+          path: data["keeper_config.xml"]
+      - isNotNull:
+          path: data["entrypoint.sh"]
+
+  - it: binds to all interfaces so raft peers and clients can connect
+    asserts:
+      - matchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "<listen_host>0.0.0.0</listen_host>"
+
+  - it: serves the client protocol on port 9181
+    asserts:
+      - matchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "<tcp_port>9181</tcp_port>"
+
+  - it: uses the raft port 9234 in the raft configuration
+    asserts:
+      - matchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "<port>9234</port>"
+
+  - it: generates one raft server per replica
+    set:
+      replicaCount: 3
+    asserts:
+      - matchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "<id>1</id>"
+      - matchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "<id>3</id>"
+      - notMatchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "<id>4</id>"
+
+  - it: derives server_id from the pod ordinal and execs keeper
+    asserts:
+      - matchRegex:
+          path: data["entrypoint.sh"]
+          pattern: 'SERVER_ID=\$\(\(ORDINAL \+ 1\)\)'
+      - matchRegex:
+          path: data["entrypoint.sh"]
+          pattern: "exec clickhouse-keeper --config"

--- a/charts/clickhouse-keeper/tests/service_test.yaml
+++ b/charts/clickhouse-keeper/tests/service_test.yaml
@@ -1,0 +1,30 @@
+suite: clickhouse-keeper headless service
+templates:
+  - templates/service-headless.yaml
+
+tests:
+  - it: renders a headless Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: clickhouse-keeper-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+
+  - it: publishes not-ready pod addresses so raft DNS resolves during bootstrap
+    asserts:
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+
+  - it: exposes the client and raft ports
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 9181
+      - equal:
+          path: spec.ports[1].port
+          value: 9234

--- a/charts/clickhouse-keeper/tests/statefulset_test.yaml
+++ b/charts/clickhouse-keeper/tests/statefulset_test.yaml
@@ -1,0 +1,98 @@
+suite: clickhouse-keeper statefulset
+templates:
+  - templates/statefulset.yaml
+
+tests:
+  - it: renders a StatefulSet with the default replica count
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: starts all pods in parallel so the raft quorum can form on first boot
+    asserts:
+      - equal:
+          path: spec.podManagementPolicy
+          value: Parallel
+
+  - it: binds the headless service for stable pod DNS
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: clickhouse-keeper-headless
+
+  - it: uses the default keeper image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: clickhouse/clickhouse-keeper:24.8
+
+  - it: exposes the client (9181) and raft (9234) ports
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 9181
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 9234
+
+  - it: mounts the config and data volumes
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/clickhouse-keeper
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /var/lib/clickhouse-keeper
+
+  - it: requests a per-replica data PVC
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: data
+
+  - it: adds soft pod anti-affinity on hostname by default
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: kubernetes.io/hostname
+
+  - it: omits affinity when podAntiAffinity is disabled
+    set:
+      podAntiAffinity: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.affinity
+
+  - it: lets a custom affinity override the default anti-affinity
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: disktype
+                    operator: In
+                    values: [ssd]
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.affinity.nodeAffinity
+      - isNull:
+          path: spec.template.spec.affinity.podAntiAffinity
+
+  - it: scales the replica count from values
+    set:
+      replicaCount: 5
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5

--- a/charts/clickhouse-keeper/values.yaml
+++ b/charts/clickhouse-keeper/values.yaml
@@ -16,3 +16,10 @@ resources:
   limits:
     cpu: "1"
     memory: 1Gi
+
+# Soft pod anti-affinity spreads keeper replicas across nodes when possible.
+# It is "preferred" (best-effort), so all replicas still schedule on 1-2 node
+# clusters. Set to false to disable. For full control, set `affinity` below
+# (a non-empty value takes precedence over this toggle).
+podAntiAffinity: true
+affinity: {}

--- a/charts/clickhouse-keeper/values.yaml
+++ b/charts/clickhouse-keeper/values.yaml
@@ -1,0 +1,18 @@
+replicaCount: 3
+image: clickhouse/clickhouse-keeper:24.8
+
+ports:
+  client: 9181
+  raft: 9234
+
+storage:
+  size: 10Gi
+  storageClassName: ""   # Use cluster default SC if empty
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi

--- a/environments/corp.example/README.md
+++ b/environments/corp.example/README.md
@@ -12,6 +12,7 @@ Actual production values live in a separate private repo and are symlinked here 
 | `vmagent.yaml.example` | Central vmagent scrape configuration (File SD targets) |
 | `victoriametrics.yaml.example` | VictoriaMetrics cluster sizing and retention |
 | `clickhouse.yaml.example` | ClickHouse cluster layout, storage, and schema init |
+| `keeper.yaml.example` | ClickHouse Keeper sizing for replicated ClickHouse clusters |
 | `grafana.yaml.example` | Grafana datasources, dashboards, ingress, and plugins |
 | `vector.yaml.example` | Vector aggregator sources, transforms, and ClickHouse sink |
 | `metadata-collector.yaml.example` | Metadata collector S2/VMware integration |

--- a/environments/corp.example/README.md
+++ b/environments/corp.example/README.md
@@ -22,8 +22,10 @@ Actual production values live in a separate private repo and are symlinked here 
 | `targets/inference-servers.json.example` | File SD target list for inference servers |
 
 All Helm values YAML files above are required for `helmfile -e corp sync`
-to succeed (except `metadata-collector.yaml.example`, which is only needed
-when `metadata_collector.enabled: true` in `values.yaml`).
+to succeed, except for these feature-gated files, which are only loaded when
+their flag is enabled in `values.yaml`:
+- `metadata-collector.yaml.example` — when `metadata_collector.enabled: true`
+- `keeper.yaml.example` — when `clickhouse_keeper.enabled: true`
 `storageclass.yaml.example` is a separate cluster prerequisite used by
 `make corp-deploy` and `make corp-sync` when the StorageClass is absent.
 Target JSON files are required when the corresponding scrape jobs are

--- a/environments/corp.example/clickhouse.yaml.example
+++ b/environments/corp.example/clickhouse.yaml.example
@@ -23,3 +23,15 @@ clickhouse:
 schema_init:
   enabled: true
   schemas_path: /schemas
+
+# Keeper coordination — required because replicasCount > 1.
+# Hosts must match the clickhouse-keeper StatefulSet (see keeper.yaml).
+keeper:
+  enabled: true
+  nodes:
+    - host: clickhouse-keeper-0.clickhouse-keeper-headless.clickhouse.svc
+      port: 9181
+    - host: clickhouse-keeper-1.clickhouse-keeper-headless.clickhouse.svc
+      port: 9181
+    - host: clickhouse-keeper-2.clickhouse-keeper-headless.clickhouse.svc
+      port: 9181

--- a/environments/corp.example/clickhouse.yaml.example
+++ b/environments/corp.example/clickhouse.yaml.example
@@ -25,9 +25,10 @@ schema_init:
   schemas_path: /schemas
 
 # Keeper coordination — required because replicasCount > 1.
-# Hosts must match the clickhouse-keeper StatefulSet (see keeper.yaml).
+# `keeper.enabled` is driven by `clickhouse_keeper.enabled` in values.yaml
+# (injected by the Helmfile), so only the node list is set here. Hosts must
+# match the clickhouse-keeper StatefulSet (see keeper.yaml).
 keeper:
-  enabled: true
   nodes:
     - host: clickhouse-keeper-0.clickhouse-keeper-headless.clickhouse.svc
       port: 9181

--- a/environments/corp.example/keeper.yaml.example
+++ b/environments/corp.example/keeper.yaml.example
@@ -1,0 +1,19 @@
+# ClickHouse Keeper values — production overrides template.
+# Copy to environments/corp/keeper.yaml (in the private repo) and adjust sizing.
+#
+# Required when clickhouse.cluster.layout.replicasCount > 1: ClickHouse needs a
+# ZooKeeper-compatible coordination service for replication. The nodes below must
+# also be listed in clickhouse.yaml under `keeper.nodes` so the
+# ClickHouseInstallation points at this keeper cluster.
+
+replicaCount: 3                  # Odd number for a raft quorum (3 or 5)
+storage:
+  size: 20Gi                     # Coordination logs/snapshots; grows with table count
+  storageClassName: "spectrum-scale"
+resources:
+  requests:
+    cpu: "500m"
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi

--- a/environments/corp.example/values.yaml.example
+++ b/environments/corp.example/values.yaml.example
@@ -16,6 +16,9 @@ metadata_collector:
 mock_dcgm:
   enabled: false         # Use real DCGM exporters in production
 
+clickhouse_keeper:
+  enabled: true          # Required when ClickHouse replicasCount > 1
+
 # Airgap: load Grafana plugins via init container (requires grafana-plugins image)
 grafana_plugins_init: true
 

--- a/environments/defaults.yaml
+++ b/environments/defaults.yaml
@@ -14,6 +14,9 @@ metadata_collector:
 mock_dcgm:
   enabled: false
 
+clickhouse_keeper:
+  enabled: false
+
 # Airgap: load Grafana plugins via init container instead of online download.
 # Requires the grafana-plugins carrier image (make build-grafana-plugins).
 grafana_plugins_init: false

--- a/environments/homelab/keeper.yaml
+++ b/environments/homelab/keeper.yaml
@@ -1,0 +1,4 @@
+# ClickHouse Keeper values — homelab overrides
+replicaCount: 3
+storage:
+  size: 5Gi

--- a/environments/homelab/keeper.yaml
+++ b/environments/homelab/keeper.yaml
@@ -1,4 +1,12 @@
-# ClickHouse Keeper values — homelab overrides
+# ClickHouse Keeper values — homelab overrides.
+#
+# INERT BY DEFAULT: homelab inherits clickhouse_keeper.enabled=false from
+# environments/defaults.yaml, so the keeper release is not deployed and this
+# file is not loaded. It exists for opt-in testing of the keeper chart, e.g.:
+#   helmfile -e homelab --state-values-set clickhouse_keeper.enabled=true template
+# To also wire ClickHouse to keeper in homelab, add `keeper.nodes` to
+# environments/homelab/clickhouse.yaml (replicasCount is 1 there, so it is not
+# required — the single-replica CHI runs fine without a zookeeper block).
 replicaCount: 3
 storage:
   size: 5Gi

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -67,6 +67,7 @@ releases:
     {{ end }}
 
   # ─── ClickHouse Keeper ────────────────────────────────────────────────────
+  {{ if .Values.clickhouse_keeper.enabled }}
   - name: clickhouse-keeper
     namespace: clickhouse
     chart: charts/clickhouse-keeper
@@ -74,6 +75,7 @@ releases:
       - clickhouse/clickhouse-operator
     values:
       - environments/{{ .Environment.Name }}/keeper.yaml
+  {{ end }}
 
   # ─── ClickHouse Cluster ───────────────────────────────────────────────────
   - name: clickhouse
@@ -82,7 +84,9 @@ releases:
     disableValidationOnInstall: true  # CRD may be absent until clickhouse-operator installs it
     needs:
       - clickhouse/clickhouse-operator
+      {{ if .Values.clickhouse_keeper.enabled }}
       - clickhouse/clickhouse-keeper
+      {{ end }}
     values:
       - environments/{{ .Environment.Name }}/clickhouse.yaml
 

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -66,6 +66,15 @@ releases:
     version: "{{ index .Values.helm_charts "altinity-clickhouse-operator" }}"
     {{ end }}
 
+  # ─── ClickHouse Keeper ────────────────────────────────────────────────────
+  - name: clickhouse-keeper
+    namespace: clickhouse
+    chart: charts/clickhouse-keeper
+    needs:
+      - clickhouse/clickhouse-operator
+    values:
+      - environments/{{ .Environment.Name }}/keeper.yaml
+
   # ─── ClickHouse Cluster ───────────────────────────────────────────────────
   - name: clickhouse
     namespace: clickhouse
@@ -73,6 +82,7 @@ releases:
     disableValidationOnInstall: true  # CRD may be absent until clickhouse-operator installs it
     needs:
       - clickhouse/clickhouse-operator
+      - clickhouse/clickhouse-keeper
     values:
       - environments/{{ .Environment.Name }}/clickhouse.yaml
 

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -89,6 +89,11 @@ releases:
       {{ end }}
     values:
       - environments/{{ .Environment.Name }}/clickhouse.yaml
+      # Single source of truth: the CHI zookeeper block is gated by the same
+      # clickhouse_keeper.enabled flag that gates the keeper release above.
+      # The env clickhouse.yaml only supplies keeper.nodes (deep-merged here).
+      - keeper:
+          enabled: {{ .Values.clickhouse_keeper.enabled }}
 
   # ─── Grafana ──────────────────────────────────────────────────────────────
   - name: grafana

--- a/scripts/validate-corp-setup.sh
+++ b/scripts/validate-corp-setup.sh
@@ -12,6 +12,7 @@ REQUIRED_VALUES=(
   vmagent.yaml
   victoriametrics.yaml
   clickhouse.yaml
+  keeper.yaml
   grafana.yaml
   vector.yaml
 )

--- a/scripts/validate-corp-setup.sh
+++ b/scripts/validate-corp-setup.sh
@@ -12,14 +12,17 @@ REQUIRED_VALUES=(
   vmagent.yaml
   victoriametrics.yaml
   clickhouse.yaml
-  keeper.yaml
   grafana.yaml
   vector.yaml
 )
 
-# metadata-collector is conditional on metadata_collector.enabled
+# Feature-gated values files — required only when their feature flag is enabled,
+# so a missing one is a warning, not an error.
+#   metadata-collector.yaml -> metadata_collector.enabled
+#   keeper.yaml             -> clickhouse_keeper.enabled
 OPTIONAL_VALUES=(
   metadata-collector.yaml
+  keeper.yaml
 )
 
 errors=0
@@ -47,10 +50,15 @@ if [ ${#missing[@]} -gt 0 ]; then
   done
 fi
 
-# 2b. Warn about missing optional values files
+# 2b. Warn about missing optional (feature-gated) values files
 for f in "${OPTIONAL_VALUES[@]}"; do
   if [ ! -f "${CORP_DIR}/${f}" ]; then
-    echo "WARN: Optional file missing: $f (needed if metadata_collector.enabled=true)"
+    case "$f" in
+      metadata-collector.yaml) reason="needed if metadata_collector.enabled=true" ;;
+      keeper.yaml)             reason="needed if clickhouse_keeper.enabled=true" ;;
+      *)                       reason="needed only when its feature is enabled" ;;
+    esac
+    echo "WARN: Optional file missing: $f ($reason)"
   fi
 done
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,6 +14,7 @@ oss_images:
   victoriametrics/vmagent: "v1.106.1"
   victoriametrics/vmalert: "v1.106.1"
   clickhouse/clickhouse-server: "24.8"
+  clickhouse/clickhouse-keeper: "24.8"
   altinity/clickhouse-operator: "0.24.0"
   grafana/grafana: "11.4.0"
   timberio/vector: "0.42.0-alpine"


### PR DESCRIPTION
## 개요
- `charts/clickhouse-keeper/` Helm 차트 추가 (StatefulSet + Headless Service + ConfigMap)
  - `entrypoint.sh`에서 pod ordinal을 읽어 `server_id` 자동 설정 (keeper-0→1, keeper-1→2, keeper-2→3)
  - `raft_configuration`은 `replicaCount` 값을 기반으로 자동 생성
- `charts/clickhouse-cluster` 업데이트: `keeper.enabled` / `keeper.nodes` 설정 시 ClickHouseInstallation에 `zookeeper.nodes` 블록 자동 삽입
- `helmfile.yaml.gotmpl` 업데이트: `clickhouse-keeper` release 추가, `clickhouse` release의 `needs`에 keeper 포함
- `environments/homelab/keeper.yaml` 추가 (3 replicas, 5Gi)

## 배경
corp 환경의 ClickHouse는 `replicasCount: 2` (2샤드 × 2레플리카)로 구성되어 있어 데이터 복제를 위한 ZooKeeper 호환 코디네이션 서비스가 필수입니다. ClickHouse Keeper는 ZooKeeper 없이 동일한 역할을 수행하는 내장 솔루션입니다.

## 테스트 체크리스트
- [ ] `helm lint charts/clickhouse-keeper` 통과
- [ ] `helm template charts/clickhouse-keeper | kubectl apply --dry-run=client -f -` 통과
- [ ] `helmfile -e homelab diff` 오류 없이 실행
- [ ] `clickhouse` 네임스페이스에 keeper Pod 3개 Running 상태 확인
- [ ] keeper 준비 완료 후 ClickHouseInstallation 클러스터 정상 동작 확인

## 관련 PR
- gpu-mon-corp: YoonsungNam/gpu-mon-corp#24 (corp 환경 설정, 이 PR 머지 후 적용)