### PR TITLE
feat(metadata-collector): S2 batch scheduler adapter

### DIFF
--- a/charts/metadata-collector/Chart.yaml
+++ b/charts/metadata-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: metadata-collector
 description: >
-  Polls legacy system APIs (Samsung S2 batch scheduler, VMware vCenter)
+  Polls batch-scheduler / hypervisor APIs (S2 batch scheduler, VMware vCenter)
   and ingests metadata into ClickHouse for enrichment with GPU metrics.
 type: application
 version: 0.1.0

--- a/charts/metadata-collector/templates/_helpers.tpl
+++ b/charts/metadata-collector/templates/_helpers.tpl
@@ -33,6 +33,27 @@ clickhouse:
 sources:
   s2:
     enabled: {{ .Values.config.sources.s2.enabled }}
+    {{- if .Values.config.sources.s2.enabled }}
+    bmi_url: {{ .Values.config.sources.s2.bmiUrl | quote }}
+    http_proxy_addr: {{ .Values.config.sources.s2.httpProxyAddr | quote }}
+    phd_bin_template: {{ .Values.config.sources.s2.phdBinTemplate | quote }}
+    ssh:
+      jump_host: {{ .Values.config.sources.s2.ssh.jumpHost | quote }}
+      login_host: {{ .Values.config.sources.s2.ssh.loginHost | quote }}
+      {{- with .Values.config.sources.s2.ssh.user }}
+      user: {{ . | quote }}
+      {{- end }}
+      key_path: {{ .Values.config.sources.s2.ssh.keyPath | quote }}
+    target_grids:
+      {{- range .Values.config.sources.s2.targetGrids }}
+      - {{ . | quote }}
+      {{- end }}
+    intervals:
+      grid_discovery: {{ .Values.config.sources.s2.intervals.gridDiscovery }}
+      nodes: {{ .Values.config.sources.s2.intervals.nodes }}
+      jobs_active: {{ .Values.config.sources.s2.intervals.jobsActive }}
+      jobs_completed: {{ .Values.config.sources.s2.intervals.jobsCompleted }}
+    {{- end }}
   vmware:
     enabled: {{ .Values.config.sources.vmware.enabled }}
 {{- end }}

--- a/charts/metadata-collector/templates/deployment.yaml
+++ b/charts/metadata-collector/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
                   key: password
             {{- end }}
             {{- with .Values.env }}
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/metadata-collector/templates/deployment.yaml
+++ b/charts/metadata-collector/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       annotations:
         checksum/config: {{ include "metadata-collector.config" . | sha256sum }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: metadata-collector
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -27,8 +31,19 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/metadata-collector
-          {{- if or .Values.existingSecrets.s2ApiToken .Values.existingSecrets.vcenterCredentials }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
+            - name: MC_CONFIG_PATH
+              value: /etc/metadata-collector/config.yaml
+            {{- if .Values.existingSecrets.clickhousePassword }}
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecrets.clickhousePassword }}
+                  key: password
+            {{- end }}
             {{- if .Values.existingSecrets.s2ApiToken }}
             - name: S2_API_TOKEN
               valueFrom:
@@ -48,9 +63,9 @@ spec:
                   name: {{ .Values.existingSecrets.vcenterCredentials }}
                   key: password
             {{- end }}
-          {{- else }}
-          env: []
-          {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 10 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -63,3 +78,6 @@ spec:
         - name: config
           configMap:
             name: {{ include "metadata-collector.fullname" . }}-config
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/metadata-collector/tests/deployment_test.yaml
+++ b/charts/metadata-collector/tests/deployment_test.yaml
@@ -68,6 +68,18 @@ tests:
                 name: my-vcenter-secret
                 key: password
 
+  - it: renders extra env entries as children of the env list
+    set:
+      env:
+        - name: EXTRA_VAR
+          value: hello
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_VAR
+            value: hello
+
   - it: has liveness probe on /health
     asserts:
       - equal:

--- a/charts/metadata-collector/values.yaml
+++ b/charts/metadata-collector/values.yaml
@@ -2,10 +2,14 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/yoonsungnam/gpu-mon/metadata-collector
-  tag: "latest"
-  pullPolicy: IfNotPresent
+  # tag is injected from versions.yaml by helmfile; override here if needed.
+  tag: "main"
+  pullPolicy: Always
 
-# Configuration is mounted from a ConfigMap + Secrets
+# Image pull secrets for private registries (set per-environment if needed).
+imagePullSecrets: []
+
+# Rendered into a ConfigMap and mounted at /etc/metadata-collector/config.yaml.
 config:
   logLevel: info
   healthPort: 8080
@@ -19,19 +23,33 @@ config:
     flushInterval: "10s"
 
   sources:
+    # S2 batch scheduler integration. Real connection values live in the
+    # private corp overlay (environments/corp/metadata-collector.yaml).
     s2:
       enabled: false
-      # Set via Secret: s2-api-token
-      # apiUrl: "http://s2-master.internal:8080/api/v1"
+      bmiUrl: ""                       # BMI REST API base URL
+      httpProxyAddr: ""                # HTTP(S) proxy for BMI calls (optional)
+      phdBinTemplate: ""               # phd binary path; {grid_name} is substituted
+      ssh:
+        jumpHost: ""                   # SSH jump/bastion host
+        loginHost: ""                  # login host where phd runs
+        user: ""                       # SSH user (optional)
+        keyPath: /root/.ssh/id_rsa
+      targetGrids: []                  # grid names to collect; empty = all discovered
+      intervals:
+        gridDiscovery: 3600
+        nodes: 600
+        jobsActive: 300
+        jobsCompleted: 600
+    # VMware vCenter integration
     vmware:
       enabled: false
-      # Set via Secret: vcenter-credentials
-      # vcenterUrl: "https://vcenter.internal.example.com"
 
-# Existing secret names (created separately, not by this chart)
+# Existing K8s secret names (created separately, not by this chart).
 existingSecrets:
-  s2ApiToken: ""         # Key: token
-  vcenterCredentials: "" # Keys: username, password
+  clickhousePassword: ""   # secret with key: password  -> CLICKHOUSE_PASSWORD
+  s2ApiToken: ""           # secret with key: token
+  vcenterCredentials: ""   # secret with keys: username, password
 
 service:
   type: ClusterIP
@@ -44,3 +62,7 @@ resources:
   limits:
     cpu: 500m
     memory: 256Mi
+
+# Extra volume mounts / volumes (e.g. an SSH key for S2). Set per-environment.
+volumeMounts: []
+volumes: []

--- a/compose/clickhouse-init/00-gpu-monitoring.sql
+++ b/compose/clickhouse-init/00-gpu-monitoring.sql
@@ -21,44 +21,53 @@ SETTINGS index_granularity = 8192;
 
 CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_jobs
 (
-    collected_at  DateTime64(3)        CODEC(Delta, ZSTD),
-    job_id        String,
-    job_name      String,
-    user_id       String,
-    team          String,
-    queue         LowCardinality(String),
-    status        LowCardinality(String),
-    submit_time   Nullable(DateTime64(3)),
-    start_time    Nullable(DateTime64(3)),
-    end_time      Nullable(DateTime64(3)),
-    node_list     Array(String),
-    gpu_count     UInt16,
-    gpu_indices   Array(UInt8),
-    cpu_count     UInt16,
-    memory_mb     UInt32,
-    exit_code     Nullable(Int32),
-    metadata      String
+    collected_at    DateTime64(3)        CODEC(Delta, ZSTD),
+    grid_name       LowCardinality(String),
+    job_id          UInt64,
+    user            String,
+    status          LowCardinality(String),
+    project         LowCardinality(String),
+    gpu_per_node    UInt16,
+    num_nodes       UInt16,
+    total_gpus      UInt32,
+    submit_time     Nullable(DateTime64(3)),
+    start_time      Nullable(DateTime64(3)),
+    end_time        Nullable(DateTime64(3)),
+    submit_ts       Float64,
+    resources       Array(String),
+    gpu_indices_raw String,
+    gpu_allocations String,
+    properties_json String,
+    raw_json        String
 )
-ENGINE = MergeTree()
+ENGINE = ReplacingMergeTree(collected_at)
 PARTITION BY toYYYYMM(collected_at)
-ORDER BY (status, collected_at, job_id)
+ORDER BY (grid_name, job_id, submit_ts)
 TTL toDateTime(collected_at) + INTERVAL 180 DAY
 SETTINGS index_granularity = 8192;
 
 CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_nodes
 (
     collected_at  DateTime64(3)        CODEC(Delta, ZSTD),
-    node_id       String,
-    status        LowCardinality(String),
-    partition     LowCardinality(String),
-    gpu_total     UInt16,
-    gpu_allocated UInt16,
-    cpu_total     UInt16,
-    cpu_allocated UInt16,
-    metadata      String
+    grid_name     LowCardinality(String),
+    hostname      String,
+    op_status     LowCardinality(String),
+    link_status   LowCardinality(String),
+    num_jobs      UInt16,
+    cores_avail   UInt32,
+    cores_used    UInt32,
+    mem_avail_gb  Float32,
+    mem_total_gb  Float32,
+    swap_avail_gb Float32,
+    swap_total_gb Float32,
+    load_1m       Float32,
+    load_5m       Float32,
+    load_15m      Float32,
+    controller    LowCardinality(String),
+    raw_json      String
 )
 ENGINE = ReplacingMergeTree(collected_at)
-ORDER BY node_id
+ORDER BY (grid_name, hostname)
 SETTINGS index_granularity = 8192;
 
 CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_pools

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -5,10 +5,10 @@ All DDL files for the `gpu_monitoring` database.
 | File | Table | Engine | Purpose |
 |---|---|---|---|
 | `gpu_unified_logs.sql` | `gpu_unified_logs` | MergeTree | Normalized logs from all environments |
-| `s2_jobs.sql` | `s2_jobs` | MergeTree | S2 batch scheduler job history (time-series) |
+| `s2_jobs.sql` | `s2_jobs` | ReplacingMergeTree | S2 batch scheduler jobs (latest status per job) |
 | `s2_nodes.sql` | `s2_nodes` | ReplacingMergeTree | S2 node current state |
-| `s2_projects.sql` | `s2_projects` | ReplacingMergeTree | S2 project/FairShare config |
-| `s2_pools.sql` | `s2_pools` | ReplacingMergeTree | S2 logical node pool config |
+| `s2_projects.sql` | `s2_projects` | ReplacingMergeTree | S2 project/FairShare config _(not populated by the current collector)_ |
+| `s2_pools.sql` | `s2_pools` | ReplacingMergeTree | S2 logical node pool config _(not populated by the current collector)_ |
 | `vmware_vm_inventory.sql` | `vmware_vm_inventory` | ReplacingMergeTree | VMware GPU VM inventory |
 
 ## Apply schemas

--- a/schemas/s2_jobs.sql
+++ b/schemas/s2_jobs.sql
@@ -1,30 +1,32 @@
--- s2_jobs: Time-series history of S2 batch scheduler jobs.
--- Each poll inserts a new row (running/pending jobs polled every 60s).
--- Enables: job wait time analysis, GPU-Hours calculation, per-job GPU Util JOIN.
+-- s2_jobs: S2 batch scheduler jobs (BMI + phd source).
+-- ReplacingMergeTree keeps the latest-collected row (latest status) per
+-- (grid_name, job_id, submit_ts). Reads use FINAL. Completed jobs are collected
+-- incrementally by end_time; the overlap window's duplicates collapse here.
 -- TTL: 6 months.
 
 CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_jobs ON CLUSTER '{cluster}'
 (
-    collected_at  DateTime64(3)             CODEC(Delta, ZSTD),
-    job_id        String,
-    job_name      String,
-    user_id       String,
-    team          String,
-    queue         LowCardinality(String),
-    status        LowCardinality(String),   -- running, pending, completed, failed, cancelled
-    submit_time   Nullable(DateTime64(3)),
-    start_time    Nullable(DateTime64(3)),
-    end_time      Nullable(DateTime64(3)),
-    node_list     Array(String),            -- ["gpu-node-01", "gpu-node-03"]
-    gpu_count     UInt16,
-    gpu_indices   Array(UInt8),             -- [0, 1, 2, 3]
-    cpu_count     UInt16,
-    memory_mb     UInt32,
-    exit_code     Nullable(Int32),
-    metadata      String                   -- JSON: extra fields from S2 API
+    collected_at    DateTime64(3)            CODEC(Delta, ZSTD),
+    grid_name       LowCardinality(String),
+    job_id          UInt64,
+    user            String,
+    status          LowCardinality(String),   -- Running, Queued, Done, Failed, Stopped
+    project         LowCardinality(String),
+    gpu_per_node    UInt16,
+    num_nodes       UInt16,
+    total_gpus      UInt32,
+    submit_time     Nullable(DateTime64(3)),
+    start_time      Nullable(DateTime64(3)),
+    end_time        Nullable(DateTime64(3)),
+    submit_ts       Float64,                  -- submit time as Unix epoch (part of the job key)
+    resources       Array(String),
+    gpu_indices_raw String,                   -- raw _gpu_indices property
+    gpu_allocations String,                   -- JSON: [{host, gpu_ids}]
+    properties_json String,                   -- JSON: full phd properties map
+    raw_json        String                    -- JSON: raw parsed job
 )
-ENGINE = MergeTree()
+ENGINE = ReplacingMergeTree(collected_at)
 PARTITION BY toYYYYMM(collected_at)
-ORDER BY (status, collected_at, job_id)
+ORDER BY (grid_name, job_id, submit_ts)
 TTL toDateTime(collected_at) + INTERVAL 180 DAY
 SETTINGS index_granularity = 8192;

--- a/schemas/s2_jobs.sql
+++ b/schemas/s2_jobs.sql
@@ -12,9 +12,9 @@ CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_jobs ON CLUSTER '{cluster}'
     user            String,
     status          LowCardinality(String),   -- Running, Queued, Done, Failed, Stopped
     project         LowCardinality(String),
-    gpu_per_node    UInt16,
+    gpu_per_node    UInt16,                   -- from phd @cores@ (S2 accounts 1 GPU card = 1 core)
     num_nodes       UInt16,
-    total_gpus      UInt32,
+    total_gpus      UInt32,                   -- gpu_per_node * num_nodes
     submit_time     Nullable(DateTime64(3)),
     start_time      Nullable(DateTime64(3)),
     end_time        Nullable(DateTime64(3)),

--- a/schemas/s2_nodes.sql
+++ b/schemas/s2_nodes.sql
@@ -1,19 +1,27 @@
--- s2_nodes: Current state of S2 scheduler nodes.
--- ReplacingMergeTree keeps only the latest row per node_id.
--- Polled every 120s.
+-- s2_nodes: Current state of S2 scheduler computing nodes (phd host source).
+-- ReplacingMergeTree keeps only the latest row per (grid_name, hostname).
+-- Polled every 10 min.
 
 CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_nodes ON CLUSTER '{cluster}'
 (
     collected_at  DateTime64(3)           CODEC(Delta, ZSTD),
-    node_id       String,
-    status        LowCardinality(String), -- idle, alloc, drain, down
-    partition     LowCardinality(String),
-    gpu_total     UInt16,
-    gpu_allocated UInt16,
-    cpu_total     UInt16,
-    cpu_allocated UInt16,
-    metadata      String
+    grid_name     LowCardinality(String),
+    hostname      String,
+    op_status     LowCardinality(String),
+    link_status   LowCardinality(String),
+    num_jobs      UInt16,
+    cores_avail   UInt32,
+    cores_used    UInt32,
+    mem_avail_gb  Float32,
+    mem_total_gb  Float32,
+    swap_avail_gb Float32,
+    swap_total_gb Float32,
+    load_1m       Float32,
+    load_5m       Float32,
+    load_15m      Float32,
+    controller    LowCardinality(String),
+    raw_json      String
 )
 ENGINE = ReplacingMergeTree(collected_at)
-ORDER BY node_id
+ORDER BY (grid_name, hostname)
 SETTINGS index_granularity = 8192;

--- a/schemas/s2_nodes.sql
+++ b/schemas/s2_nodes.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS gpu_monitoring.s2_nodes ON CLUSTER '{cluster}'
     op_status     LowCardinality(String),
     link_status   LowCardinality(String),
     num_jobs      UInt16,
-    cores_avail   UInt32,
+    cores_avail   UInt32,                 -- S2 core accounting: on GPU grids 1 GPU card = 1 core
     cores_used    UInt32,
     mem_avail_gb  Float32,
     mem_total_gb  Float32,

--- a/src/metadata-collector/.gitignore
+++ b/src/metadata-collector/.gitignore
@@ -1,0 +1,3 @@
+*.csv
+*.crt
+temp

--- a/src/metadata-collector/Dockerfile
+++ b/src/metadata-collector/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.12-alpine
 
-RUN apk add --no-cache gcc musl-dev libffi-dev openssl-dev
+# Build + runtime packages (openssh-client is required for the S2 ssh ProxyCommand).
+RUN apk add --no-cache gcc musl-dev libffi-dev openssl-dev openssh-client
 
 WORKDIR /app
 COPY requirements.txt .

--- a/src/metadata-collector/adapters/s2_adapter.py
+++ b/src/metadata-collector/adapters/s2_adapter.py
@@ -1,158 +1,687 @@
 """
-Samsung S2 Batch Scheduler adapter.
+S2 Batch Scheduler adapter.
 
-Polls S2 REST API and normalizes job/node/project/pool data
-into the gpu_monitoring ClickHouse schema.
+Collects GPU node/job metadata from the in-house S2 scheduler via:
+  1) BMI REST API   → grid discovery & portal node spec  (via Squid proxy)
+  2) ssh -J         → run ``phd host`` on the login server   (via jump host)
+  3) ssh -J         → run ``phd list`` on the login server   (via jump host)
+
+Job collection strategy
+-----------------------
+- **Active jobs** (Running + Queued): full collection every cycle.
+    ``phd list -a -r``  /  ``phd list -a -q``
+- **Completed jobs** (Done + Failed + Stopped): end_time-based window collection.
+    ``phd list -a -sel "(status==Done || ...) && end_time > TS"``
+  TS = last collected end_time - overlap buffer (10 min).
+  Duplicates caused by the overlap are removed by ReplacingMergeTree.
+  On pod restart, the last end_time is recovered from ClickHouse.
+
+ClickHouse target tables:
+  - s2_nodes  (Distributed → ReplicatedMergeTree)
+  - s2_jobs   (Distributed → ReplicatedReplacingMergeTree)
 """
 
+import ast
 import json
 import logging
-from datetime import datetime, timezone
-from typing import Dict, List, Optional
+import os
+import re
+import shlex
+import subprocess
+import time
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional
 
 import requests
 
 logger = logging.getLogger(__name__)
 
+# KST (UTC+9)
+_KST = timezone(timedelta(hours=9))
 
-def _parse_time(val) -> Optional[datetime]:
-    if not val:
+# overlap buffer (seconds) for completed job collection.
+# Prevents missing jobs at the previous collection boundary. Duplicates are
+# handled by ReplacingMergeTree.
+_COMPLETED_OVERLAP_SECS = 600  # 10 min
+
+# Maximum lookback range (seconds) on the first collection (last_end_ts=0).
+# Avoids a full scan to prevent OOM.
+_INITIAL_LOOKBACK_SECS = 86400 * 7  # 7 days
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Utility helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+def _int(s: str) -> int:
+    try:
+        return int(s)
+    except (ValueError, TypeError):
+        return 0
+
+
+def _float(s: str) -> float:
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _ts_to_datetime(ts: float) -> Optional[datetime]:
+    """Unix timestamp → KST datetime.  Returns None if 0."""
+    if not ts or ts <= 0:
         return None
     try:
-        return datetime.fromisoformat(str(val).replace("Z", "+00:00"))
-    except ValueError:
+        return datetime.fromtimestamp(ts, tz=_KST)
+    except (OSError, ValueError):
         return None
 
 
-class S2Adapter:
-    """Wraps multiple S2 data types behind a single API client."""
+def _safe_literal_eval(s: str):
+    try:
+        return ast.literal_eval(s.strip())
+    except (ValueError, SyntaxError):
+        return None
 
-    def __init__(self, api_url: str, api_token: str, writer):
-        self.api_url = api_url.rstrip("/")
-        self.session = requests.Session()
-        self.session.headers["Authorization"] = f"Bearer {api_token}"
-        self.session.headers["Accept"] = "application/json"
-        self.writer = writer
 
-    def _get(self, path: str, params: dict = None) -> dict:
-        url = f"{self.api_url}{path}"
-        resp = self.session.get(url, params=params, timeout=30)
+def _parse_gpu_indices(gpu_indices_str: str) -> List[Dict[str, Any]]:
+    """_gpu_indices string → per-host GPU allocation list."""
+    if not gpu_indices_str:
+        return []
+    allocations: List[Dict[str, Any]] = []
+    for segment in gpu_indices_str.split("|"):
+        segment = segment.strip()
+        if not segment:
+            continue
+        m = re.match(r"^([A-Za-z0-9_\-]+)\[([^\]]+)\]$", segment)
+        if not m:
+            logger.warning("gpu_indices segment parse fail: %s", segment)
+            continue
+        host = m.group(1)
+        gpu_ids = []
+        for part in m.group(2).split(","):
+            nums = re.findall(r"\d+", part.strip())
+            if nums:
+                gpu_ids.append(int(nums[-1]))
+        allocations.append({"host": host, "gpu_ids": gpu_ids})
+    return allocations
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  BMI Client
+# ═══════════════════════════════════════════════════════════════════════
+
+class _BMIClient:
+    def __init__(self, base_url: str, proxies: dict):
+        self._base = base_url.rstrip("/")
+        self._session = requests.Session()
+        self._session.proxies.update(proxies)
+        self._session.headers["Accept"] = "application/json"
+
+    def get_grids(self) -> List[str]:
+        url = f"{self._base}/api/v2/grid"
+        logger.info("BMI GET %s", url)
+        resp = self._session.get(url, timeout=15)
         resp.raise_for_status()
-        return resp.json()
+        return [item["name"] for item in resp.json()]
 
-    # ── Jobs ─────────────────────────────────────────────────────────────
+    def get_portal_spec(self, grid_name: str) -> str:
+        url = f"{self._base}/api/v2/grid/{grid_name}/machinelist/pnodes"
+        logger.info("BMI GET %s", url)
+        resp = self._session.get(url, timeout=15)
+        resp.raise_for_status()
+        pnodes = resp.json()
+        if not pnodes:
+            return ""
+        pn = pnodes[0]
+        machine = pn["machine"].split(".")[0]
+        return f"{pn['port']}@{machine}"
 
-    def collect_jobs_running(self):
-        self._collect_jobs(statuses=["running", "pending"])
 
-    def collect_jobs_completed(self):
-        self._collect_jobs(statuses=["completed", "failed", "cancelled"], since="24h")
+# ═══════════════════════════════════════════════════════════════════════
+#  SSH PHD runner
+# ═══════════════════════════════════════════════════════════════════════
 
-    def _collect_jobs(self, statuses: List[str], since: str = None):
+class _SSHPHDRunner:
+    def __init__(
+        self,
+        phd_bin_template: str,
+        jump_host: str,
+        login_host: str,
+        ssh_user: Optional[str] = None,
+        ssh_key_path: Optional[str] = None,
+        ssh_port: int = 22,
+        ssh_options: Optional[List[str]] = None,
+    ):
+        self._phd_template = phd_bin_template
+        self._jump_host = jump_host
+        self._login_host = login_host
+        self._ssh_user = ssh_user
+        self._ssh_key_path = ssh_key_path
+        self._ssh_port = ssh_port
+        self._ssh_options = ssh_options or []
+
+    def _build_ssh_cmd(self, remote_cmd: str) -> List[str]:
+        ssh_opts = (
+            "-o StrictHostKeyChecking=no "
+            "-o UserKnownHostsFile=/dev/null "
+            "-o BatchMode=yes"
+        )
+        jump_spec = self._jump_host
+        if self._ssh_user:
+            jump_spec = f"{self._ssh_user}@{self._jump_host}"
+        key_opt = f"-i {self._ssh_key_path} " if self._ssh_key_path else ""
+        proxy_cmd = f"ssh {ssh_opts} {key_opt}-W %h:%p {jump_spec}"
+
+        cmd = ["ssh"]
+        cmd += [
+            "-o", "BatchMode=yes",
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "ConnectTimeout=15",
+            "-o", f"ProxyCommand={proxy_cmd}",
+        ]
+        if self._ssh_key_path:
+            cmd += ["-i", self._ssh_key_path]
+        if self._ssh_port != 22:
+            cmd += ["-p", str(self._ssh_port)]
+        cmd += self._ssh_options
+
+        target = self._login_host
+        if self._ssh_user:
+            target = f"{self._ssh_user}@{self._login_host}"
+        cmd.append(target)
+        cmd.append(remote_cmd)
+        return cmd
+
+    def run(self, args: List[str], grid_name: str) -> str:
+        phd_bin = self._phd_template.format(grid_name=grid_name)
+        remote_parts = [phd_bin] + args
+        remote_cmd = " ".join(shlex.quote(p) for p in remote_parts)
+        ssh_cmd = self._build_ssh_cmd(remote_cmd)
+        logger.debug("exec: %s", " ".join(ssh_cmd))
+
         try:
-            params = {"status": ",".join(statuses)}
-            if since:
-                params["since"] = since
-            data = self._get("/jobs", params)
-            rows = [_normalize_job(j) for j in data.get("jobs", [])]
-            if rows:
-                self.writer.insert("s2_jobs", rows)
-            logger.debug("s2 jobs collected: %d rows (%s)", len(rows), statuses)
-        except Exception as e:
-            logger.error("s2 collect_jobs failed: %s", e)
+            result = subprocess.run(
+                ssh_cmd, capture_output=True, text=True, timeout=120,
+            )
+            if result.returncode != 0:
+                logger.error(
+                    "ssh+phd failed (rc=%d, host=%s): %s",
+                    result.returncode, self._login_host, result.stderr.strip(),
+                )
+                return ""
+            return result.stdout
+        except subprocess.TimeoutExpired:
+            logger.error("ssh+phd timeout (host=%s)", self._login_host)
+            return ""
+        except FileNotFoundError:
+            logger.error("ssh binary not found in PATH")
+            return ""
 
-    # ── Nodes ─────────────────────────────────────────────────────────────
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Parsers
+# ═══════════════════════════════════════════════════════════════════════
+
+def _parse_phd_host(raw: str) -> List[Dict[str, Any]]:
+    nodes: List[Dict[str, Any]] = []
+    in_data = False
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("---"):
+            in_data = True
+            continue
+        if not in_data or not stripped:
+            continue
+        tokens = stripped.split()
+        if len(tokens) < 13:
+            logger.warning("node line skipped (tokens=%d): %s", len(tokens), stripped)
+            continue
+        op_link = tokens[1].split("/", 1)
+        nodes.append({
+            "hostname":      tokens[0],
+            "op_status":     op_link[0],
+            "link_status":   op_link[1] if len(op_link) > 1 else "",
+            "num_jobs":      _int(tokens[2]),
+            "cores_avail":   _int(tokens[3]),
+            "cores_used":    _int(tokens[4]),
+            "mem_avail_gb":  _float(tokens[5]),
+            "mem_total_gb":  _float(tokens[6]),
+            "swap_avail_gb": _float(tokens[7]),
+            "swap_total_gb": _float(tokens[8]),
+            "load_1m":       _float(tokens[9]),
+            "load_5m":       _float(tokens[10]),
+            "load_15m":      _float(tokens[11]),
+            "controller":    tokens[12],
+        })
+    return nodes
+
+
+_LIST_FORMAT = (
+    "@id@ @user@ @status@ @project@ @cores@ @dp_num_cnodes@ "
+    "@submit_time@ @start_time@ @end_time@ "
+    "@resources@ @properties@"
+)
+
+
+def _parse_phd_list(raw: str) -> List[Dict[str, Any]]:
+    jobs: List[Dict[str, Any]] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        job = _parse_job_line(stripped)
+        if job is not None:
+            jobs.append(job)
+    return jobs
+
+
+def _parse_job_line(line: str) -> Optional[Dict[str, Any]]:
+    """9 fixed fields + [...] resources + {...} properties."""
+    try:
+        bracket_idx = line.index("[")
+    except ValueError:
+        logger.warning("job line has no array: %s", line)
+        return None
+
+    fixed = line[:bracket_idx].strip().split()
+    if len(fixed) < 9:
+        logger.warning("job line fixed fields < 9: %s", line)
+        return None
+
+    rest = line[bracket_idx:]
+
+    resources = []
+    res_match = re.search(r"\[.*?\]", rest)
+    if res_match:
+        parsed = _safe_literal_eval(res_match.group())
+        if isinstance(parsed, list):
+            resources = [str(x) for x in parsed]
+
+    properties = {}
+    props_match = re.search(r"\{.*\}", rest)
+    if props_match:
+        parsed = _safe_literal_eval(props_match.group())
+        if isinstance(parsed, dict):
+            properties = parsed
+
+    gpu_per_node = _int(fixed[4])
+    num_nodes = _int(fixed[5])
+    submit_ts = _float(fixed[6])
+    start_ts = _float(fixed[7])
+    end_ts = _float(fixed[8])
+
+    gpu_indices_raw = str(properties.get("_gpu_indices", ""))
+    gpu_allocations = _parse_gpu_indices(gpu_indices_raw)
+
+    return {
+        "job_id":           int(fixed[0]),
+        "user":             fixed[1],
+        "status":           fixed[2],
+        "project":          fixed[3],
+        "gpu_per_node":     gpu_per_node,
+        "num_nodes":        num_nodes,
+        "total_gpus":       gpu_per_node * num_nodes,
+        "submit_time":      _ts_to_datetime(submit_ts),
+        "start_time":       _ts_to_datetime(start_ts),
+        "end_time":         _ts_to_datetime(end_ts),
+        "submit_ts":        submit_ts,
+        "end_ts":           end_ts,
+        "resources":        resources,
+        "gpu_indices_raw":  gpu_indices_raw,
+        "gpu_allocations":  gpu_allocations,
+        "properties":       properties,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Normalizers
+# ═══════════════════════════════════════════════════════════════════════
+
+def _normalize_node(grid_name: str, raw: Dict) -> Dict:
+    return {
+        "collected_at":  datetime.now(_KST),
+        "grid_name":     grid_name,
+        "hostname":      raw["hostname"],
+        "op_status":     raw["op_status"],
+        "link_status":   raw["link_status"],
+        "num_jobs":      raw["num_jobs"],
+        "cores_avail":   raw["cores_avail"],
+        "cores_used":    raw["cores_used"],
+        "mem_avail_gb":  raw["mem_avail_gb"],
+        "mem_total_gb":  raw["mem_total_gb"],
+        "swap_avail_gb": raw["swap_avail_gb"],
+        "swap_total_gb": raw["swap_total_gb"],
+        "load_1m":       raw["load_1m"],
+        "load_5m":       raw["load_5m"],
+        "load_15m":      raw["load_15m"],
+        "controller":    raw["controller"],
+        "raw_json":      json.dumps(raw, ensure_ascii=False, default=str),
+    }
+
+
+def _normalize_job(grid_name: str, raw: Dict) -> Dict:
+    return {
+        "collected_at":     datetime.now(_KST),
+        "grid_name":        grid_name,
+        "job_id":           raw["job_id"],
+        "user":             raw["user"],
+        "status":           raw["status"],
+        "project":          raw["project"],
+        "gpu_per_node":     raw["gpu_per_node"],
+        "num_nodes":        raw["num_nodes"],
+        "total_gpus":       raw["total_gpus"],
+        "submit_time":      raw["submit_time"],
+        "start_time":       raw["start_time"],
+        "end_time":         raw["end_time"],
+        "submit_ts":        raw["submit_ts"],
+        "resources":        raw["resources"],
+        "gpu_indices_raw":  raw["gpu_indices_raw"],
+        "gpu_allocations":  json.dumps(raw["gpu_allocations"], ensure_ascii=False),
+        "properties_json":  json.dumps(raw["properties"], ensure_ascii=False),
+        "raw_json":         json.dumps(raw, ensure_ascii=False, default=str),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  S2Adapter
+# ═══════════════════════════════════════════════════════════════════════
+
+class S2Adapter:
+    """S2 batch scheduler metadata adapter.
+
+    Collection strategy
+    -------------------
+    - ``collect_jobs_active()``: full collection of Running + Queued  (every 1 min)
+    - ``collect_jobs_completed()``: Done/Failed/Stopped **end_time window** collection  (every 5 min)
+      - ``end_time > (last_end_ts - overlap)`` collects only recently finished jobs
+      - overlap (10 min) prevents boundary gaps; duplicates are removed by ReplacingMergeTree
+      - last_end_ts is recovered from ClickHouse on pod restart
+    """
+
+    _COMPLETED_STATUSES = "Done", "Failed", "Stopped"
+    _COMPLETED_SEL_STATUS = " || ".join(f"status=={s}" for s in _COMPLETED_STATUSES)
+
+    def __init__(
+        self,
+        bmi_url: str,
+        phd_bin_template: str,
+        http_proxy_addr: str,
+        ssh_jump_host: str,
+        ssh_login_host: str,
+        writer,
+        ssh_user: Optional[str] = None,
+        ssh_key_path: Optional[str] = None,
+        target_grids: Optional[List[str]] = None,
+    ):
+        self.writer = writer
+        self._target_grids = target_grids
+
+        proxies = {"http": http_proxy_addr, "https": http_proxy_addr}
+        self._bmi = _BMIClient(bmi_url, proxies)
+        self._phd = _SSHPHDRunner(
+            phd_bin_template=phd_bin_template,
+            jump_host=ssh_jump_host,
+            login_host=ssh_login_host,
+            ssh_user=ssh_user,
+            ssh_key_path=ssh_key_path,
+        )
+
+        self._grid_map: Dict[str, str] = {}
+
+        # grid → end_time of the last collected completed job (Unix timestamp)
+        self._last_end_ts: Dict[str, float] = {}
+
+    # ── Grid discovery ───────────────────────────────────────────────────
+
+    def refresh_grids(self):
+        try:
+            all_grids = self._bmi.get_grids()
+            targets = self._target_grids or all_grids
+            new_map: Dict[str, str] = {}
+            for g in targets:
+                if g not in all_grids:
+                    logger.warning("target grid '%s' not in BMI — skipped", g)
+                    continue
+                spec = self._bmi.get_portal_spec(g)
+                if spec:
+                    new_map[g] = spec
+            self._grid_map = new_map
+            logger.info("grid map refreshed: %s", self._grid_map)
+        except Exception as e:
+            logger.error("refresh_grids failed: %s", e)
+
+    def _ensure_grids(self):
+        if not self._grid_map:
+            self.refresh_grids()
+
+    # ── last_end_ts management ───────────────────────────────────────────
+
+    def _recover_last_end_ts(self, grid_name: str) -> float:
+        """Query the maximum end_time among completed jobs for the grid from ClickHouse.
+
+        On pod restart the in-memory _last_end_ts is empty, so the last value
+        is recovered from the DB.
+        Returns 0.0 on query failure → falls back to full collection on the first cycle.
+        """
+        statuses = ", ".join(f"'{s}'" for s in self._COMPLETED_STATUSES)
+        # Unqualified table name -> resolves to the writer's configured database
+        # (same DB the writes go to). Watermark is the latest end_time, not submit_ts.
+        query = (
+            f"SELECT max(toUnixTimestamp(end_time)) FROM s2_jobs FINAL "
+            f"WHERE grid_name = %(grid)s AND status IN ({statuses}) "
+            f"AND end_time IS NOT NULL"
+        )
+        try:
+            result = self.writer._client.execute(query, {"grid": grid_name})
+            val = result[0][0] if result and result[0] else 0
+            ts = float(val) if val else 0.0
+            if ts > 0:
+                logger.info(
+                    "Recovered last_end_ts from CH: grid=%s, ts=%.1f (%s)",
+                    grid_name, ts, _ts_to_datetime(ts),
+                )
+            return ts
+        except Exception as e:
+            logger.warning(
+                "Failed to recover last_end_ts from CH (grid=%s): %s — will fetch all",
+                grid_name, e,
+            )
+            return 0.0
+
+    def _get_last_end_ts(self, grid_name: str) -> float:
+        """Return the grid's last_end_ts.  Recover from CH if not present."""
+        if grid_name not in self._last_end_ts:
+            self._last_end_ts[grid_name] = self._recover_last_end_ts(grid_name)
+        return self._last_end_ts[grid_name]
+
+    def _update_last_end_ts(self, grid_name: str, jobs: List[Dict]):
+        """Update with the maximum end_ts among the collected completed jobs."""
+        if not jobs:
+            return
+        end_timestamps = [j["end_ts"] for j in jobs if j.get("end_ts", 0) > 0]
+        if not end_timestamps:
+            return
+        max_ts = max(end_timestamps)
+        current = self._last_end_ts.get(grid_name, 0.0)
+        if max_ts > current:
+            self._last_end_ts[grid_name] = max_ts
+            logger.debug(
+                "last_end_ts updated: grid=%s, %.1f → %.1f", grid_name, current, max_ts,
+            )
+
+    # ── Nodes ────────────────────────────────────────────────────────────
 
     def collect_nodes(self):
+        """Collect the computing-node status of every grid → s2_nodes."""
+        self._ensure_grids()
+        for grid_name in self._grid_map:
+            try:
+                raw = self._phd.run(["host"], grid_name)
+                parsed = _parse_phd_host(raw)
+                rows = [_normalize_node(grid_name, n) for n in parsed]
+                if rows:
+                    self.writer.insert("s2_nodes", rows)
+                logger.debug("s2 nodes: grid=%s, rows=%d", grid_name, len(rows))
+            except Exception as e:
+                logger.error("s2 collect_nodes failed (grid=%s): %s", grid_name, e)
+
+    # ── Active jobs (Running + Queued) ───────────────────────────────────
+
+    def collect_jobs_active(self):
+        """Collect all Running + Queued jobs → s2_jobs.
+
+        After collection, look up in ClickHouse the jobs that were previously
+        Running/Queued but no longer appear in this collection, and close them
+        as Done.
+        (Handles the case where a job went Running → Done → purge and the
+        collection opportunity was missed.)
+        """
+        self._ensure_grids()
+        for grid_name in self._grid_map:
+            active_job_keys: set = set()  # (job_id, submit_ts)
+            collection_ok = True
+
+            for flag, label in [("-r", "Running"), ("-q", "Queued")]:
+                try:
+                    raw = self._phd.run(
+                        ["list", "-a", flag, "-O", _LIST_FORMAT],
+                        grid_name,
+                    )
+                    parsed = _parse_phd_list(raw)
+                    rows = [_normalize_job(grid_name, j) for j in parsed]
+                    if rows:
+                        self.writer.insert("s2_jobs", rows)
+                    for j in parsed:
+                        active_job_keys.add((j["job_id"], j["submit_ts"]))
+                    logger.debug(
+                        "s2 jobs [%s]: grid=%s, rows=%d", label, grid_name, len(rows),
+                    )
+                except Exception as e:
+                    logger.error(
+                        "s2 collect_jobs_%s failed (grid=%s): %s", label, grid_name, e,
+                    )
+                    collection_ok = False
+
+            # If any phd call failed, do not perform vanished detection
+            # (prevents all jobs from being closed as Done due to a network issue)
+            if collection_ok:
+                self._close_vanished_jobs(grid_name, active_job_keys)
+
+    # ── Close vanished jobs ──────────────────────────────────────────────
+
+    def _close_vanished_jobs(self, grid_name: str, active_job_keys: set):
+        """Close as Done the jobs that are Running/Queued in CH but no longer present in phd.
+
+        Parameters
+        ----------
+        grid_name : str
+        active_job_keys : set of (job_id, submit_ts)
+            The active job keys confirmed from phd in this collection.
+        """
         try:
-            data = self._get("/nodes")
-            rows = [_normalize_node(n) for n in data.get("nodes", [])]
-            if rows:
-                self.writer.insert("s2_nodes", rows)
-            logger.debug("s2 nodes collected: %d rows", len(rows))
+            query = (
+                "SELECT job_id, user, project, gpu_per_node, num_nodes, "
+                "       total_gpus, submit_time, start_time, submit_ts, "
+                "       resources, gpu_indices_raw, gpu_allocations, "
+                "       properties_json "
+                "FROM s2_jobs FINAL "
+                "WHERE grid_name = %(grid)s "
+                "  AND status IN ('Running', 'Queued')"
+            )
+            ch_rows = self.writer._client.execute(query, {"grid": grid_name})
         except Exception as e:
-            logger.error("s2 collect_nodes failed: %s", e)
+            logger.warning("_close_vanished_jobs CH query failed (grid=%s): %s", grid_name, e)
+            return
 
-    # ── Projects ──────────────────────────────────────────────────────────
+        if not ch_rows:
+            return
 
-    def collect_projects(self):
-        try:
-            data = self._get("/projects")
-            rows = [_normalize_project(p) for p in data.get("projects", [])]
-            if rows:
-                self.writer.insert("s2_projects", rows)
-            logger.debug("s2 projects collected: %d rows", len(rows))
-        except Exception as e:
-            logger.error("s2 collect_projects failed: %s", e)
+        now = datetime.now(_KST)
+        closed_rows = []
 
-    # ── Pools ─────────────────────────────────────────────────────────────
+        for row in ch_rows:
+            job_id = row[0]
+            submit_ts = float(row[8]) if row[8] else 0.0
+            key = (job_id, submit_ts)
 
-    def collect_pools(self):
-        try:
-            data = self._get("/pools")
-            rows = [_normalize_pool(p) for p in data.get("pools", [])]
-            if rows:
-                self.writer.insert("s2_pools", rows)
-            logger.debug("s2 pools collected: %d rows", len(rows))
-        except Exception as e:
-            logger.error("s2 collect_pools failed: %s", e)
+            if key not in active_job_keys:
+                closed_rows.append({
+                    "collected_at":     now,
+                    "grid_name":        grid_name,
+                    "job_id":           job_id,
+                    "user":             row[1] or "",
+                    "status":           "Done",
+                    "project":          row[2] or "",
+                    "gpu_per_node":     row[3] or 0,
+                    "num_nodes":        row[4] or 0,
+                    "total_gpus":       row[5] or 0,
+                    "submit_time":      row[6],
+                    "start_time":       row[7],
+                    "end_time":         now,
+                    "submit_ts":        submit_ts,
+                    "resources":        row[9] or [],
+                    "gpu_indices_raw":  row[10] or "",
+                    "gpu_allocations":  row[11] or "[]",
+                    "properties_json":  row[12] or "{}",
+                    "raw_json":         json.dumps({"_closed_by": "vanished_detection"}),
+                })
 
+        if closed_rows:
+            self.writer.insert("s2_jobs", closed_rows)
+            logger.info(
+                "Closed %d vanished jobs as Done: grid=%s, job_ids=%s",
+                len(closed_rows), grid_name,
+                [r["job_id"] for r in closed_rows[:10]],
+            )
 
-# ─── Normalizers ──────────────────────────────────────────────────────────────
+    # ── Completed jobs (Done + Failed + Stopped) ─────────────────────────
 
-def _normalize_job(raw: Dict) -> Dict:
-    return {
-        "collected_at":  datetime.now(timezone.utc),
-        "job_id":        str(raw.get("id", "")),
-        "job_name":      raw.get("name", ""),
-        "user_id":       raw.get("user", ""),
-        "team":          raw.get("group", ""),
-        "queue":         raw.get("partition", "default"),
-        "status":        raw.get("state", ""),
-        "submit_time":   _parse_time(raw.get("submit_time")),
-        "start_time":    _parse_time(raw.get("start_time")),
-        "end_time":      _parse_time(raw.get("end_time")),
-        "node_list":     raw.get("nodes", []),
-        "gpu_count":     int(raw.get("gpu_count", 0)),
-        "gpu_indices":   raw.get("gpu_indices", []),
-        "cpu_count":     int(raw.get("cpu_count", 0)),
-        "memory_mb":     int(raw.get("memory_mb", 0)),
-        "exit_code":     raw.get("exit_code"),
-        "metadata":      json.dumps(raw.get("extra", {})),
-    }
+    def collect_jobs_completed(self):
+        """Collect completed jobs by end_time window → s2_jobs.
 
+        ``phd list -a -sel "(status==Done || ...) && end_time > TS"``
 
-def _normalize_node(raw: Dict) -> Dict:
-    return {
-        "collected_at":  datetime.now(timezone.utc),
-        "node_id":       raw.get("name", ""),
-        "status":        raw.get("state", ""),
-        "partition":     raw.get("partition", ""),
-        "gpu_total":     int(raw.get("gpu_total", 0)),
-        "gpu_allocated": int(raw.get("gpu_allocated", 0)),
-        "cpu_total":     int(raw.get("cpu_total", 0)),
-        "cpu_allocated": int(raw.get("cpu_allocated", 0)),
-        "metadata":      json.dumps(raw.get("extra", {})),
-    }
+        TS = last_end_ts - overlap (10 min).
+        If last_end_ts is 0 (first collection / recovery failure), collect only
+        the last 7 days to prevent OOM.
+        overlap prevents boundary gaps; duplicates are removed by ReplacingMergeTree.
+        """
+        self._ensure_grids()
+        for grid_name in self._grid_map:
+            try:
+                last_ts = self._get_last_end_ts(grid_name)
 
+                if last_ts > 0:
+                    # Normal: collect starting from overlap before the last end_time
+                    window_ts = last_ts - _COMPLETED_OVERLAP_SECS
+                else:
+                    # First collection or recovery failure: collect only the last 7 days (prevents OOM)
+                    window_ts = time.time() - _INITIAL_LOOKBACK_SECS
+                    logger.info(
+                        "First completed collection for grid=%s, "
+                        "limiting to last %d days",
+                        grid_name, _INITIAL_LOOKBACK_SECS // 86400,
+                    )
 
-def _normalize_project(raw: Dict) -> Dict:
-    return {
-        "collected_at":     datetime.now(timezone.utc),
-        "project_id":       str(raw.get("id", "")),
-        "project_name":     raw.get("name", ""),
-        "fairshare_weight": float(raw.get("fairshare", 1.0)),
-        "gpu_limit":        int(raw.get("gpu_limit", 0)),
-        "metadata":         json.dumps(raw),
-    }
-
-
-def _normalize_pool(raw: Dict) -> Dict:
-    return {
-        "collected_at": datetime.now(timezone.utc),
-        "pool_id":      str(raw.get("id", "")),
-        "pool_name":    raw.get("name", ""),
-        "node_list":    raw.get("nodes", []),
-        "gpu_total":    int(raw.get("gpu_total", 0)),
-        "metadata":     json.dumps(raw),
-    }
+                sel_expr = (
+                    f"({self._COMPLETED_SEL_STATUS}) && end_time > {window_ts}"
+                )
+                raw = self._phd.run(
+                    ["list", "-a", "-sel", sel_expr, "-O", _LIST_FORMAT],
+                    grid_name,
+                )
+                parsed = _parse_phd_list(raw)
+                rows = [_normalize_job(grid_name, j) for j in parsed]
+                if rows:
+                    self.writer.insert("s2_jobs", rows)
+                    self._update_last_end_ts(grid_name, parsed)
+                logger.debug(
+                    "s2 jobs [Completed]: grid=%s, rows=%d (end_time > %.1f)",
+                    grid_name, len(rows), window_ts,
+                )
+            except Exception as e:
+                logger.error(
+                    "s2 collect_jobs_completed failed (grid=%s): %s", grid_name, e,
+                )

--- a/src/metadata-collector/adapters/s2_adapter.py
+++ b/src/metadata-collector/adapters/s2_adapter.py
@@ -24,12 +24,11 @@ ClickHouse target tables:
 import ast
 import json
 import logging
-import os
 import re
 import shlex
 import subprocess
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 import requests

--- a/src/metadata-collector/adapters/s2_adapter.py
+++ b/src/metadata-collector/adapters/s2_adapter.py
@@ -276,6 +276,10 @@ def _parse_phd_host(raw: str) -> List[Dict[str, Any]]:
     return nodes
 
 
+# Note @cores@: S2 treats GPUs as first-class assets and accounts one GPU
+# card as one core, so on GPU grids @cores@ is the per-node GPU count (the
+# token name is historical, from CPU scheduling). Confirmed by the S2
+# operators; this is why it maps to gpu_per_node below.
 _LIST_FORMAT = (
     "@id@ @user@ @status@ @project@ @cores@ @dp_num_cnodes@ "
     "@submit_time@ @start_time@ @end_time@ "

--- a/src/metadata-collector/adapters/s2_adapter.py
+++ b/src/metadata-collector/adapters/s2_adapter.py
@@ -17,8 +17,8 @@ Job collection strategy
   On pod restart, the last end_time is recovered from ClickHouse.
 
 ClickHouse target tables:
-  - s2_nodes  (Distributed → ReplicatedMergeTree)
-  - s2_jobs   (Distributed → ReplicatedReplacingMergeTree)
+  - s2_nodes  (ReplacingMergeTree)
+  - s2_jobs   (ReplacingMergeTree)
 """
 
 import ast
@@ -142,6 +142,10 @@ class _BMIClient:
 #  SSH PHD runner
 # ═══════════════════════════════════════════════════════════════════════
 
+class PhdCommandError(RuntimeError):
+    """The remote phd command could not be executed or exited non-zero."""
+
+
 class _SSHPHDRunner:
     def __init__(
         self,
@@ -195,6 +199,14 @@ class _SSHPHDRunner:
         return cmd
 
     def run(self, args: List[str], grid_name: str) -> str:
+        """Run phd remotely and return its stdout.
+
+        Raises PhdCommandError on any execution failure (non-zero exit,
+        timeout, missing ssh binary) so callers can tell "phd failed" apart
+        from "phd succeeded with no matching jobs" (empty stdout). Returning
+        an empty string on failure would make vanished-job detection treat
+        every active job as gone.
+        """
         phd_bin = self._phd_template.format(grid_name=grid_name)
         remote_parts = [phd_bin] + args
         remote_cmd = " ".join(shlex.quote(p) for p in remote_parts)
@@ -205,19 +217,25 @@ class _SSHPHDRunner:
             result = subprocess.run(
                 ssh_cmd, capture_output=True, text=True, timeout=120,
             )
-            if result.returncode != 0:
-                logger.error(
-                    "ssh+phd failed (rc=%d, host=%s): %s",
-                    result.returncode, self._login_host, result.stderr.strip(),
-                )
-                return ""
-            return result.stdout
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             logger.error("ssh+phd timeout (host=%s)", self._login_host)
-            return ""
-        except FileNotFoundError:
+            raise PhdCommandError(
+                f"ssh+phd timeout (host={self._login_host})"
+            ) from e
+        except FileNotFoundError as e:
             logger.error("ssh binary not found in PATH")
-            return ""
+            raise PhdCommandError("ssh binary not found in PATH") from e
+
+        if result.returncode != 0:
+            logger.error(
+                "ssh+phd failed (rc=%d, host=%s): %s",
+                result.returncode, self._login_host, result.stderr.strip(),
+            )
+            raise PhdCommandError(
+                f"ssh+phd failed (rc={result.returncode}, "
+                f"host={self._login_host}): {result.stderr.strip()}"
+            )
+        return result.stdout
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -393,8 +411,8 @@ class S2Adapter:
 
     Collection strategy
     -------------------
-    - ``collect_jobs_active()``: full collection of Running + Queued  (every 1 min)
-    - ``collect_jobs_completed()``: Done/Failed/Stopped **end_time window** collection  (every 5 min)
+    - ``collect_jobs_active()``: full collection of Running + Queued  (default every 5 min)
+    - ``collect_jobs_completed()``: Done/Failed/Stopped **end_time window** collection  (default every 10 min)
       - ``end_time > (last_end_ts - overlap)`` collects only recently finished jobs
       - overlap (10 min) prevents boundary gaps; duplicates are removed by ReplacingMergeTree
       - last_end_ts is recovered from ClickHouse on pod restart
@@ -444,9 +462,12 @@ class S2Adapter:
                 if g not in all_grids:
                     logger.warning("target grid '%s' not in BMI — skipped", g)
                     continue
+                # The portal spec is informational; a grid without portal
+                # pnodes must still be collected.
                 spec = self._bmi.get_portal_spec(g)
-                if spec:
-                    new_map[g] = spec
+                if not spec:
+                    logger.warning("grid '%s' has no portal pnodes", g)
+                new_map[g] = spec
             self._grid_map = new_map
             logger.info("grid map refreshed: %s", self._grid_map)
         except Exception as e:
@@ -474,7 +495,7 @@ class S2Adapter:
             f"AND end_time IS NOT NULL"
         )
         try:
-            result = self.writer._client.execute(query, {"grid": grid_name})
+            result = self.writer.query(query, {"grid": grid_name})
             val = result[0][0] if result and result[0] else 0
             ts = float(val) if val else 0.0
             if ts > 0:
@@ -534,7 +555,7 @@ class S2Adapter:
 
         After collection, look up in ClickHouse the jobs that were previously
         Running/Queued but no longer appear in this collection, and close them
-        as Done.
+        (Running → Done, Queued → Stopped).
         (Handles the case where a job went Running → Done → purge and the
         collection opportunity was missed.)
         """
@@ -564,15 +585,20 @@ class S2Adapter:
                     )
                     collection_ok = False
 
-            # If any phd call failed, do not perform vanished detection
-            # (prevents all jobs from being closed as Done due to a network issue)
+            # If any phd call failed (PhdCommandError or otherwise), do not
+            # perform vanished detection — with a partial/empty active set a
+            # network issue would close every active job.
             if collection_ok:
                 self._close_vanished_jobs(grid_name, active_job_keys)
 
     # ── Close vanished jobs ──────────────────────────────────────────────
 
     def _close_vanished_jobs(self, grid_name: str, active_job_keys: set):
-        """Close as Done the jobs that are Running/Queued in CH but no longer present in phd.
+        """Close the jobs that are Running/Queued in CH but no longer present in phd.
+
+        A vanished Running job finished → Done. A vanished Queued job never
+        ran (cancelled/removed) → Stopped, so completion metrics are not
+        inflated.
 
         Parameters
         ----------
@@ -585,12 +611,12 @@ class S2Adapter:
                 "SELECT job_id, user, project, gpu_per_node, num_nodes, "
                 "       total_gpus, submit_time, start_time, submit_ts, "
                 "       resources, gpu_indices_raw, gpu_allocations, "
-                "       properties_json "
+                "       properties_json, status "
                 "FROM s2_jobs FINAL "
                 "WHERE grid_name = %(grid)s "
                 "  AND status IN ('Running', 'Queued')"
             )
-            ch_rows = self.writer._client.execute(query, {"grid": grid_name})
+            ch_rows = self.writer.query(query, {"grid": grid_name})
         except Exception as e:
             logger.warning("_close_vanished_jobs CH query failed (grid=%s): %s", grid_name, e)
             return
@@ -607,12 +633,13 @@ class S2Adapter:
             key = (job_id, submit_ts)
 
             if key not in active_job_keys:
+                prior_status = row[13]
                 closed_rows.append({
                     "collected_at":     now,
                     "grid_name":        grid_name,
                     "job_id":           job_id,
                     "user":             row[1] or "",
-                    "status":           "Done",
+                    "status":           "Done" if prior_status == "Running" else "Stopped",
                     "project":          row[2] or "",
                     "gpu_per_node":     row[3] or 0,
                     "num_nodes":        row[4] or 0,
@@ -625,13 +652,16 @@ class S2Adapter:
                     "gpu_indices_raw":  row[10] or "",
                     "gpu_allocations":  row[11] or "[]",
                     "properties_json":  row[12] or "{}",
-                    "raw_json":         json.dumps({"_closed_by": "vanished_detection"}),
+                    "raw_json":         json.dumps({
+                        "_closed_by": "vanished_detection",
+                        "prior_status": prior_status,
+                    }),
                 })
 
         if closed_rows:
             self.writer.insert("s2_jobs", closed_rows)
             logger.info(
-                "Closed %d vanished jobs as Done: grid=%s, job_ids=%s",
+                "Closed %d vanished jobs: grid=%s, job_ids=%s",
                 len(closed_rows), grid_name,
                 [r["job_id"] for r in closed_rows[:10]],
             )
@@ -676,7 +706,12 @@ class S2Adapter:
                 rows = [_normalize_job(grid_name, j) for j in parsed]
                 if rows:
                     self.writer.insert("s2_jobs", rows)
-                    self._update_last_end_ts(grid_name, parsed)
+                    # Advance the watermark only once the rows are persisted:
+                    # buffered rows are invisible to _recover_last_end_ts, so
+                    # a crash would otherwise skip them on restart. On flush
+                    # failure the window simply re-covers them next cycle.
+                    if self.writer.flush():
+                        self._update_last_end_ts(grid_name, parsed)
                 logger.debug(
                     "s2 jobs [Completed]: grid=%s, rows=%d (end_time > %.1f)",
                     grid_name, len(rows), window_ts,

--- a/src/metadata-collector/config.yaml
+++ b/src/metadata-collector/config.yaml
@@ -1,0 +1,42 @@
+# Local development example config.
+# In Kubernetes this file is replaced by the chart-rendered ConfigMap,
+# mounted at /etc/metadata-collector/config.yaml (via the MC_CONFIG_PATH env var).
+# Real environment values live in the private corp overlay, not here.
+collector:
+  log_level: info
+  health_port: 8080
+
+clickhouse:
+  endpoints:
+    - "clickhouse-gpu-monitoring.clickhouse.svc:9000"
+  database: gpu_monitoring
+  username: metadata_writer
+  # password: set via CLICKHOUSE_PASSWORD env var
+  batch_size: 500
+  flush_interval: 10s
+
+sources:
+  s2:
+    enabled: false
+    bmi_url: "http://s2-bmi.example.internal:8080"
+    http_proxy_addr: "http://proxy.example.internal:3128"
+    phd_bin_template: "/opt/s2/installed/{grid_name}/current/bin/phd"
+
+    ssh:
+      jump_host: "jump.example.internal"
+      login_host: "login.example.internal"
+      # user: svcuser
+      key_path: /root/.ssh/id_rsa
+
+    target_grids:
+      - example-grid
+
+    # Collection intervals (seconds)
+    intervals:
+      grid_discovery: 3600    # grid/portal discovery (60 min)
+      nodes: 600              # phd host (10 min)
+      jobs_active: 300        # Running + Queued, full snapshot (5 min)
+      jobs_completed: 600     # Done + Failed + Stopped, incremental (10 min)
+
+  vmware:
+    enabled: false

--- a/src/metadata-collector/main.py
+++ b/src/metadata-collector/main.py
@@ -11,6 +11,7 @@ import logging
 import os
 import signal
 import sys
+from pathlib import Path
 
 import yaml
 from adapters.s2_adapter import S2Adapter
@@ -18,7 +19,6 @@ from adapters.vmware_adapter import VMwareAdapter
 from health import HealthServer
 from scheduler import CollectorScheduler
 from writer.clickhouse_writer import ClickHouseWriter
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/src/metadata-collector/main.py
+++ b/src/metadata-collector/main.py
@@ -1,13 +1,10 @@
 """
 Metadata Collector
 
-Polls legacy system APIs (Samsung S2 batch scheduler, VMware vCenter)
+Polls batch-scheduler / hypervisor APIs (S2 batch scheduler, VMware vCenter)
 on configurable schedules and batch-inserts metadata into ClickHouse.
 
-Enables GPU metric enrichment: GPU Util + Job context at query time.
-
-Config: /etc/metadata-collector/config.yaml
-        or MC_CONFIG_PATH env var
+Config: /etc/metadata-collector/config.yaml  or  MC_CONFIG_PATH env var
 """
 
 import logging
@@ -21,6 +18,7 @@ from adapters.vmware_adapter import VMwareAdapter
 from health import HealthServer
 from scheduler import CollectorScheduler
 from writer.clickhouse_writer import ClickHouseWriter
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +29,10 @@ def load_config(path: str) -> dict:
 
 
 def main():
+    base_dir = Path(__file__).resolve().parent
     config_path = os.environ.get(
-        "MC_CONFIG_PATH", "/etc/metadata-collector/config.yaml"
+        "MC_CONFIG_PATH",
+        str(base_dir / "config.yaml")
     )
 
     try:
@@ -64,17 +64,53 @@ def main():
     # ── S2 Adapter ───────────────────────────────────────────────────────
     s2_cfg = sources.get("s2", {})
     if s2_cfg.get("enabled", False):
+        ssh_cfg = s2_cfg.get("ssh", {})
         s2 = S2Adapter(
-            api_url=s2_cfg.get("api_url", ""),
-            api_token=os.environ.get("S2_API_TOKEN", ""),
+            bmi_url=s2_cfg.get("bmi_url", ""),
+            phd_bin_template=s2_cfg.get(
+                "phd_bin_template",
+                "/opt/s2/installed/{grid_name}/current/bin/phd",
+            ),
+            http_proxy_addr=s2_cfg.get("http_proxy_addr", ""),
+            ssh_jump_host=ssh_cfg.get("jump_host", ""),
+            ssh_login_host=ssh_cfg.get("login_host", ""),
             writer=writer,
+            ssh_user=ssh_cfg.get("user"),
+            ssh_key_path=ssh_cfg.get("key_path"),
+            target_grids=s2_cfg.get("target_grids"),
         )
-        scheduler.add(s2.collect_jobs_running,    interval_secs=60,  name="s2-jobs-running")
-        scheduler.add(s2.collect_jobs_completed,  interval_secs=300, name="s2-jobs-completed")
-        scheduler.add(s2.collect_nodes,           interval_secs=120, name="s2-nodes")
-        scheduler.add(s2.collect_projects,        interval_secs=600, name="s2-projects")
-        scheduler.add(s2.collect_pools,           interval_secs=600, name="s2-pools")
-        logger.info("S2 adapter enabled: %s", s2_cfg.get("api_url"))
+
+        intervals = s2_cfg.get("intervals", {})
+
+        # grid discovery — every 60 min
+        scheduler.add(
+            s2.refresh_grids,
+            interval_secs=intervals.get("grid_discovery", 3600),
+            name="s2-grid-discovery",
+        )
+        # node info — every 10 min
+        scheduler.add(
+            s2.collect_nodes,
+            interval_secs=intervals.get("nodes", 600),
+            name="s2-nodes",
+        )
+        # Running + Queued jobs — every 5 min
+        scheduler.add(
+            s2.collect_jobs_active,
+            interval_secs=intervals.get("jobs_active", 300),
+            name="s2-jobs-active",
+        )
+        # Done + Failed + Stopped jobs — every 10 min (incremental)
+        scheduler.add(
+            s2.collect_jobs_completed,
+            interval_secs=intervals.get("jobs_completed", 600),
+            name="s2-jobs-completed",
+        )
+
+        logger.info(
+            "S2 adapter enabled: bmi=%s, login=%s",
+            s2_cfg.get("bmi_url"), ssh_cfg.get("login_host"),
+        )
 
     # ── VMware Adapter ───────────────────────────────────────────────────
     vmw_cfg = sources.get("vmware", {})

--- a/src/metadata-collector/tests/test_s2_adapter.py
+++ b/src/metadata-collector/tests/test_s2_adapter.py
@@ -1,7 +1,18 @@
 """
-Unit tests for S2 adapter: normalize functions + collect methods.
+Unit tests for the S2 adapter (BMI REST + SSH 'phd' command design).
 
-All HTTP calls are mocked — no real S2 API required.
+All network/SSH is mocked — no real BMI API, jump host, or login server
+required.  ``subprocess.run`` and the BMI ``requests.Session`` are patched so
+the tests are fully deterministic.
+
+Coverage:
+  - pure helpers: _int / _float / _ts_to_datetime / _safe_literal_eval
+  - parsers: _parse_gpu_indices, _parse_phd_host, _parse_job_line, _parse_phd_list
+  - normalizers: _normalize_node, _normalize_job
+  - _BMIClient.get_grids / get_portal_spec (mocked Session)
+  - _SSHPHDRunner.run (mocked subprocess.run)
+  - S2Adapter.refresh_grids / collect_nodes / collect_jobs_active /
+    collect_jobs_completed / _close_vanished_jobs
 """
 
 import json
@@ -14,242 +25,763 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from adapters.s2_adapter import (
+from adapters.s2_adapter import (  # noqa: E402
+    _LIST_FORMAT,
     S2Adapter,
+    _BMIClient,
+    _float,
+    _int,
     _normalize_job,
     _normalize_node,
-    _normalize_pool,
-    _normalize_project,
-    _parse_time,
+    _parse_gpu_indices,
+    _parse_job_line,
+    _parse_phd_host,
+    _parse_phd_list,
+    _safe_literal_eval,
+    _SSHPHDRunner,
+    _ts_to_datetime,
 )
 
-# ─── _parse_time ─────────────────────────────────────────────────────────────
+# A real-ish unix timestamp (2025-07-15 09:00:00 KST area).
+_TS_SUBMIT = 1752537600.0
+_TS_START = 1752537900.0
+_TS_END = 1752541200.0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  _int / _float
+# ═══════════════════════════════════════════════════════════════════════
 
 @pytest.mark.unit
-def test_parse_time_iso_string():
-    result = _parse_time("2025-07-15T09:00:00Z")
-    assert isinstance(result, datetime)
-
-
-@pytest.mark.unit
-def test_parse_time_none_returns_none():
-    assert _parse_time(None) is None
-
-
-@pytest.mark.unit
-def test_parse_time_empty_string_returns_none():
-    assert _parse_time("") is None
+def test_int_parses_valid():
+    assert _int("42") == 42
 
 
 @pytest.mark.unit
-def test_parse_time_invalid_returns_none():
-    assert _parse_time("not-a-date") is None
-
-
-# ─── _normalize_job ──────────────────────────────────────────────────────────
-
-@pytest.fixture
-def raw_job():
-    return {
-        "id": 84723,
-        "name": "llama-training",
-        "user": "kim",
-        "group": "ai-research",
-        "partition": "high-priority",
-        "state": "running",
-        "submit_time": "2025-07-15T09:00:00Z",
-        "start_time": "2025-07-15T09:05:00Z",
-        "end_time": None,
-        "nodes": ["gpu-node-03"],
-        "gpu_count": 4,
-        "gpu_indices": [0, 1, 2, 3],
-        "cpu_count": 32,
-        "memory_mb": 65536,
-        "exit_code": None,
-        "extra": {"priority": 100},
-    }
+def test_int_fallback_on_garbage():
+    assert _int("not-a-number") == 0
+    assert _int(None) == 0
+    assert _int("") == 0
 
 
 @pytest.mark.unit
-def test_normalize_job_fields(raw_job):
-    row = _normalize_job(raw_job)
-    assert row["job_id"] == "84723"
-    assert row["job_name"] == "llama-training"
-    assert row["user_id"] == "kim"
-    assert row["team"] == "ai-research"
-    assert row["queue"] == "high-priority"
-    assert row["status"] == "running"
-    assert row["node_list"] == ["gpu-node-03"]
-    assert row["gpu_count"] == 4
-    assert row["gpu_indices"] == [0, 1, 2, 3]
-    assert row["cpu_count"] == 32
-    assert row["memory_mb"] == 65536
-    assert row["exit_code"] is None
+def test_float_parses_valid():
+    assert _float("3.5") == pytest.approx(3.5)
 
 
 @pytest.mark.unit
-def test_normalize_job_collected_at_is_utc(raw_job):
-    row = _normalize_job(raw_job)
-    assert isinstance(row["collected_at"], datetime)
+def test_float_fallback_on_garbage():
+    assert _float("x") == pytest.approx(0.0)
+    assert _float(None) == pytest.approx(0.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  _ts_to_datetime
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_ts_to_datetime_zero_is_none():
+    assert _ts_to_datetime(0) is None
 
 
 @pytest.mark.unit
-def test_normalize_job_metadata_is_json(raw_job):
-    row = _normalize_job(raw_job)
-    parsed = json.loads(row["metadata"])
-    assert parsed["priority"] == 100
+def test_ts_to_datetime_negative_is_none():
+    assert _ts_to_datetime(-5) is None
 
 
 @pytest.mark.unit
-def test_normalize_job_missing_optional_fields():
-    """Minimal raw job — only required fields — should not raise."""
-    row = _normalize_job({"id": 1, "user": "u", "state": "pending"})
-    assert row["job_id"] == "1"
-    assert row["queue"] == "default"
-    assert row["gpu_count"] == 0
-    assert row["node_list"] == []
+def test_ts_to_datetime_real_timestamp():
+    dt = _ts_to_datetime(_TS_SUBMIT)
+    assert isinstance(dt, datetime)
+    # adapter uses KST (UTC+9)
+    assert dt.utcoffset().total_seconds() == pytest.approx(9 * 3600)
 
 
-# ─── _normalize_node ─────────────────────────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════════
+#  _safe_literal_eval
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_safe_literal_eval_list():
+    assert _safe_literal_eval("['a', 'b']") == ["a", "b"]
+
+
+@pytest.mark.unit
+def test_safe_literal_eval_dict():
+    assert _safe_literal_eval("{'k': 1}") == {"k": 1}
+
+
+@pytest.mark.unit
+def test_safe_literal_eval_invalid_returns_none():
+    assert _safe_literal_eval("this is not python") is None
+    assert _safe_literal_eval("{unterminated") is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  _parse_gpu_indices
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_parse_gpu_indices_empty():
+    assert _parse_gpu_indices("") == []
+
+
+@pytest.mark.unit
+def test_parse_gpu_indices_single_host():
+    result = _parse_gpu_indices("gpu-node-03[0,1,2,3]")
+    assert result == [{"host": "gpu-node-03", "gpu_ids": [0, 1, 2, 3]}]
+
+
+@pytest.mark.unit
+def test_parse_gpu_indices_multi_host():
+    result = _parse_gpu_indices("nodeA[0,1] | nodeB[2,3]")
+    assert result == [
+        {"host": "nodeA", "gpu_ids": [0, 1]},
+        {"host": "nodeB", "gpu_ids": [2, 3]},
+    ]
+
+
+@pytest.mark.unit
+def test_parse_gpu_indices_skips_malformed_segment():
+    # 'garbage' has no [..] block → skipped; valid one still parsed
+    result = _parse_gpu_indices("garbage | nodeB[5]")
+    assert result == [{"host": "nodeB", "gpu_ids": [5]}]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  _parse_phd_host
+# ═══════════════════════════════════════════════════════════════════════
+
+_PHD_HOST_OUTPUT = """\
+host  op/link  jobs cores ucores memA memT swpA swpT l1 l5 l15 controller
+------------------------------------------------------------------------
+gpu-node-01 up/connected 2 64 32 500.5 512.0 8.0 16.0 1.5 1.2 0.9 ctrl-a
+gpu-node-02 down/lost 0 64 0 510.0 512.0 16.0 16.0 0.1 0.2 0.3 ctrl-b
+short line with too few tokens
+"""
+
+
+@pytest.mark.unit
+def test_parse_phd_host_happy_path():
+    nodes = _parse_phd_host(_PHD_HOST_OUTPUT)
+    assert len(nodes) == 2  # the short line is skipped
+
+    n0 = nodes[0]
+    assert n0["hostname"] == "gpu-node-01"
+    assert n0["op_status"] == "up"
+    assert n0["link_status"] == "connected"
+    assert n0["num_jobs"] == 2
+    assert n0["cores_avail"] == 64
+    assert n0["cores_used"] == 32
+    assert n0["mem_avail_gb"] == pytest.approx(500.5)
+    assert n0["mem_total_gb"] == pytest.approx(512.0)
+    assert n0["swap_avail_gb"] == pytest.approx(8.0)
+    assert n0["swap_total_gb"] == pytest.approx(16.0)
+    assert n0["load_1m"] == pytest.approx(1.5)
+    assert n0["load_5m"] == pytest.approx(1.2)
+    assert n0["load_15m"] == pytest.approx(0.9)
+    assert n0["controller"] == "ctrl-a"
+
+
+@pytest.mark.unit
+def test_parse_phd_host_op_without_link():
+    raw = (
+        "h o c\n"
+        "----\n"
+        "node-x running 1 64 0 1.0 2.0 3.0 4.0 0.1 0.2 0.3 ctrl\n"
+    )
+    nodes = _parse_phd_host(raw)
+    assert len(nodes) == 1
+    assert nodes[0]["op_status"] == "running"
+    assert nodes[0]["link_status"] == ""  # no '/' in token
+
+
+@pytest.mark.unit
+def test_parse_phd_host_ignores_lines_before_separator():
+    raw = "garbage header that should be ignored\nignored too\n"
+    # no '---' separator → nothing is treated as data
+    assert _parse_phd_host(raw) == []
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  _parse_job_line / _parse_phd_list
+# ═══════════════════════════════════════════════════════════════════════
+
+def _job_line(
+    job_id=84723,
+    user="kim",
+    status="Running",
+    project="ai-research",
+    gpu_per_node=4,
+    num_nodes=2,
+    submit_ts=_TS_SUBMIT,
+    start_ts=_TS_START,
+    end_ts=_TS_END,
+    resources="['gpu', 'highmem']",
+    properties="{'_gpu_indices': 'nodeA[0,1,2,3] | nodeB[0,1,2,3]', 'prio': 100}",
+):
+    return (
+        f"{job_id} {user} {status} {project} {gpu_per_node} {num_nodes} "
+        f"{submit_ts} {start_ts} {end_ts} {resources} {properties}"
+    )
+
+
+@pytest.mark.unit
+def test_parse_job_line_full():
+    job = _parse_job_line(_job_line())
+    assert job is not None
+    assert job["job_id"] == 84723
+    assert job["user"] == "kim"
+    assert job["status"] == "Running"
+    assert job["project"] == "ai-research"
+    assert job["gpu_per_node"] == 4
+    assert job["num_nodes"] == 2
+    assert job["total_gpus"] == 8  # 4 * 2
+    assert job["resources"] == ["gpu", "highmem"]
+    assert job["submit_ts"] == pytest.approx(_TS_SUBMIT)
+    assert job["end_ts"] == pytest.approx(_TS_END)
+    assert isinstance(job["submit_time"], datetime)
+    assert isinstance(job["start_time"], datetime)
+    assert isinstance(job["end_time"], datetime)
+    assert job["properties"]["prio"] == 100
+
+
+@pytest.mark.unit
+def test_parse_job_line_gpu_indices_in_properties():
+    job = _parse_job_line(_job_line())
+    assert job["gpu_indices_raw"] == "nodeA[0,1,2,3] | nodeB[0,1,2,3]"
+    assert job["gpu_allocations"] == [
+        {"host": "nodeA", "gpu_ids": [0, 1, 2, 3]},
+        {"host": "nodeB", "gpu_ids": [0, 1, 2, 3]},
+    ]
+
+
+@pytest.mark.unit
+def test_parse_job_line_no_bracket_returns_none():
+    # no '[' → no resources array → rejected
+    assert _parse_job_line("1 kim Running proj 1 1 0 0 0 no-array-here") is None
+
+
+@pytest.mark.unit
+def test_parse_job_line_too_few_fixed_fields_returns_none():
+    # only 4 fixed fields before the '[' → < 9 → rejected
+    assert _parse_job_line("1 kim Running proj ['gpu'] {}") is None
+
+
+@pytest.mark.unit
+def test_parse_job_line_unfinished_end_time_is_none():
+    # end_ts == 0 → end_time should be None (running job)
+    job = _parse_job_line(_job_line(status="Running", end_ts=0))
+    assert job is not None
+    assert job["end_time"] is None
+    assert job["end_ts"] == pytest.approx(0.0)
+
+
+@pytest.mark.unit
+def test_parse_phd_list_multiple_lines_and_blank():
+    raw = (
+        _job_line(job_id=1)
+        + "\n\n"  # blank line ignored
+        + _job_line(job_id=2)
+        + "\n"
+    )
+    jobs = _parse_phd_list(raw)
+    assert [j["job_id"] for j in jobs] == [1, 2]
+
+
+@pytest.mark.unit
+def test_parse_phd_list_skips_unparseable_line():
+    raw = _job_line(job_id=1) + "\nthis line has no bracket\n"
+    jobs = _parse_phd_list(raw)
+    assert [j["job_id"] for j in jobs] == [1]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  _normalize_node
+# ═══════════════════════════════════════════════════════════════════════
 
 @pytest.fixture
 def raw_node():
     return {
-        "name": "gpu-node-01",
-        "state": "alloc",
-        "partition": "high-priority",
-        "gpu_total": 8,
-        "gpu_allocated": 4,
-        "cpu_total": 64,
-        "cpu_allocated": 32,
+        "hostname": "gpu-node-01",
+        "op_status": "up",
+        "link_status": "connected",
+        "num_jobs": 2,
+        "cores_avail": 64,
+        "cores_used": 32,
+        "mem_avail_gb": 500.5,
+        "mem_total_gb": 512.0,
+        "swap_avail_gb": 8.0,
+        "swap_total_gb": 16.0,
+        "load_1m": 1.5,
+        "load_5m": 1.2,
+        "load_15m": 0.9,
+        "controller": "ctrl-a",
     }
 
 
 @pytest.mark.unit
-def test_normalize_node_fields(raw_node):
-    row = _normalize_node(raw_node)
-    assert row["node_id"] == "gpu-node-01"
-    assert row["status"] == "alloc"
-    assert row["partition"] == "high-priority"
-    assert row["gpu_total"] == 8
-    assert row["gpu_allocated"] == 4
-    assert row["cpu_total"] == 64
-    assert row["cpu_allocated"] == 32
+def test_normalize_node_field_mapping(raw_node):
+    row = _normalize_node("grid-east", raw_node)
+    assert row["grid_name"] == "grid-east"
+    assert row["hostname"] == "gpu-node-01"
+    assert row["op_status"] == "up"
+    assert row["link_status"] == "connected"
+    assert row["num_jobs"] == 2
+    assert row["cores_avail"] == 64
+    assert row["cores_used"] == 32
+    assert row["mem_avail_gb"] == pytest.approx(500.5)
+    assert row["controller"] == "ctrl-a"
+    assert isinstance(row["collected_at"], datetime)
 
 
 @pytest.mark.unit
-def test_normalize_node_missing_fields():
-    row = _normalize_node({"name": "node-x"})
-    assert row["node_id"] == "node-x"
-    assert row["gpu_total"] == 0
+def test_normalize_node_raw_json_roundtrip(raw_node):
+    row = _normalize_node("grid-east", raw_node)
+    parsed = json.loads(row["raw_json"])
+    assert parsed["hostname"] == "gpu-node-01"
+    assert parsed["controller"] == "ctrl-a"
 
 
-# ─── _normalize_project ──────────────────────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════════
+#  _normalize_job
+# ═══════════════════════════════════════════════════════════════════════
 
-@pytest.mark.unit
-def test_normalize_project_fields():
-    raw = {"id": 7, "name": "ai-research", "fairshare": 0.8, "gpu_limit": 500}
-    row = _normalize_project(raw)
-    assert row["project_id"] == "7"
-    assert row["project_name"] == "ai-research"
-    assert row["fairshare_weight"] == pytest.approx(0.8)
-    assert row["gpu_limit"] == 500
+@pytest.fixture
+def raw_job():
+    return _parse_job_line(_job_line())
 
 
 @pytest.mark.unit
-def test_normalize_project_defaults():
-    row = _normalize_project({"id": 1, "name": "p"})
-    assert row["fairshare_weight"] == pytest.approx(1.0)
-    assert row["gpu_limit"] == 0
+def test_normalize_job_field_mapping(raw_job):
+    row = _normalize_job("grid-west", raw_job)
+    assert row["grid_name"] == "grid-west"
+    assert row["job_id"] == 84723
+    assert row["user"] == "kim"
+    assert row["status"] == "Running"
+    assert row["project"] == "ai-research"
+    assert row["gpu_per_node"] == 4
+    assert row["num_nodes"] == 2
+    assert row["total_gpus"] == 8
+    assert row["submit_ts"] == pytest.approx(_TS_SUBMIT)
+    assert row["resources"] == ["gpu", "highmem"]
+    assert row["gpu_indices_raw"] == "nodeA[0,1,2,3] | nodeB[0,1,2,3]"
+    assert isinstance(row["collected_at"], datetime)
 
-
-# ─── _normalize_pool ─────────────────────────────────────────────────────────
 
 @pytest.mark.unit
-def test_normalize_pool_fields():
-    raw = {"id": 3, "name": "gpu-pool-a", "nodes": ["n1", "n2"], "gpu_total": 16}
-    row = _normalize_pool(raw)
-    assert row["pool_id"] == "3"
-    assert row["pool_name"] == "gpu-pool-a"
-    assert row["node_list"] == ["n1", "n2"]
-    assert row["gpu_total"] == 16
+def test_normalize_job_json_columns(raw_job):
+    row = _normalize_job("grid-west", raw_job)
+    allocs = json.loads(row["gpu_allocations"])
+    assert allocs[0]["host"] == "nodeA"
+    props = json.loads(row["properties_json"])
+    assert props["prio"] == 100
+    # raw_json is serialisable even though it contains datetimes (default=str)
+    assert isinstance(json.loads(row["raw_json"]), dict)
 
 
-# ─── S2Adapter.collect_* with mocked HTTP ────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════════
+#  _BMIClient (mocked requests.Session)
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_bmi_get_grids():
+    with patch("adapters.s2_adapter.requests.Session") as mock_session_cls:
+        session = MagicMock()
+        mock_session_cls.return_value = session
+        resp = MagicMock()
+        resp.json.return_value = [{"name": "grid-a"}, {"name": "grid-b"}]
+        session.get.return_value = resp
+
+        client = _BMIClient("http://bmi.test/", {})
+        grids = client.get_grids()
+
+    assert grids == ["grid-a", "grid-b"]
+    called_url = session.get.call_args[0][0]
+    assert called_url == "http://bmi.test/api/v2/grid"
+
+
+@pytest.mark.unit
+def test_bmi_get_portal_spec():
+    with patch("adapters.s2_adapter.requests.Session") as mock_session_cls:
+        session = MagicMock()
+        mock_session_cls.return_value = session
+        resp = MagicMock()
+        resp.json.return_value = [{"port": 6789, "machine": "login01.corp.example.com"}]
+        session.get.return_value = resp
+
+        client = _BMIClient("http://bmi.test", {})
+        spec = client.get_portal_spec("grid-a")
+
+    # machine domain stripped → "<port>@<short-host>"
+    assert spec == "6789@login01"
+
+
+@pytest.mark.unit
+def test_bmi_get_portal_spec_empty():
+    with patch("adapters.s2_adapter.requests.Session") as mock_session_cls:
+        session = MagicMock()
+        mock_session_cls.return_value = session
+        resp = MagicMock()
+        resp.json.return_value = []
+        session.get.return_value = resp
+
+        client = _BMIClient("http://bmi.test", {})
+        assert client.get_portal_spec("grid-a") == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  _SSHPHDRunner (mocked subprocess.run)
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_ssh_phd_runner_returns_stdout():
+    runner = _SSHPHDRunner(
+        phd_bin_template="/opt/{grid_name}/bin/phd",
+        jump_host="jump.test",
+        login_host="login.test",
+        ssh_user="svc",
+    )
+    completed = MagicMock(returncode=0, stdout="PHD OUTPUT", stderr="")
+    with patch("adapters.s2_adapter.subprocess.run", return_value=completed) as mrun:
+        out = runner.run(["host"], "grid-a")
+
+    assert out == "PHD OUTPUT"
+    ssh_cmd = mrun.call_args[0][0]
+    assert ssh_cmd[0] == "ssh"
+    # phd binary template formatted with the grid name, sent as the remote cmd
+    assert "/opt/grid-a/bin/phd" in ssh_cmd[-1]
+    # target host carries the ssh_user
+    assert "svc@login.test" in ssh_cmd
+
+
+@pytest.mark.unit
+def test_ssh_phd_runner_nonzero_returns_empty():
+    runner = _SSHPHDRunner(
+        phd_bin_template="phd",
+        jump_host="jump.test",
+        login_host="login.test",
+    )
+    completed = MagicMock(returncode=1, stdout="partial", stderr="boom")
+    with patch("adapters.s2_adapter.subprocess.run", return_value=completed):
+        assert runner.run(["host"], "grid-a") == ""
+
+
+@pytest.mark.unit
+def test_ssh_phd_runner_timeout_returns_empty():
+    import subprocess as _sp
+
+    runner = _SSHPHDRunner(
+        phd_bin_template="phd",
+        jump_host="jump.test",
+        login_host="login.test",
+    )
+    with patch(
+        "adapters.s2_adapter.subprocess.run",
+        side_effect=_sp.TimeoutExpired(cmd="ssh", timeout=120),
+    ):
+        assert runner.run(["host"], "grid-a") == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  S2Adapter — fixtures
+# ═══════════════════════════════════════════════════════════════════════
 
 @pytest.fixture
 def mock_writer():
     w = MagicMock()
     w.insert = MagicMock()
+    # writer._client.execute used for CH recovery / vanished detection
+    w._client = MagicMock()
+    w._client.execute = MagicMock(return_value=[])
     return w
 
 
 @pytest.fixture
 def adapter(mock_writer):
-    with patch("adapters.s2_adapter.requests.Session") as mock_session_cls:
-        session = MagicMock()
-        mock_session_cls.return_value = session
-
+    """An S2Adapter whose BMI client and SSH runner are replaced by mocks."""
+    with patch("adapters.s2_adapter.requests.Session"):
         a = S2Adapter(
-            api_url="http://s2-master.test:8080/api/v1",
-            api_token="test-token",
+            bmi_url="http://bmi.test",
+            phd_bin_template="/opt/{grid_name}/bin/phd",
+            http_proxy_addr="http://squid.test:3128",
+            ssh_jump_host="jump.test",
+            ssh_login_host="login.test",
             writer=mock_writer,
+            ssh_user="svc",
+            target_grids=["grid-a"],
         )
-        a._session_mock = session  # expose for per-test setup
-        return a
+    a._bmi = MagicMock()
+    a._phd = MagicMock()
+    return a
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  S2Adapter.refresh_grids
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_refresh_grids_builds_map(adapter):
+    adapter._bmi.get_grids.return_value = ["grid-a", "grid-b"]
+    adapter._bmi.get_portal_spec.return_value = "6789@login01"
+
+    adapter.refresh_grids()
+
+    # only the target grid 'grid-a' is kept
+    assert adapter._grid_map == {"grid-a": "6789@login01"}
 
 
 @pytest.mark.unit
-def test_collect_jobs_running_calls_writer(adapter, mock_writer):
-    fake_response = MagicMock()
-    fake_response.json.return_value = {
-        "jobs": [{"id": 1, "user": "u", "state": "running"}]
-    }
-    fake_response.raise_for_status = MagicMock()
-    adapter.session.get.return_value = fake_response
+def test_refresh_grids_skips_target_not_in_bmi(adapter):
+    # target grid-a is NOT returned by BMI → skipped, map stays empty
+    adapter._bmi.get_grids.return_value = ["grid-z"]
+    adapter._bmi.get_portal_spec.return_value = "1@x"
 
-    adapter.collect_jobs_running()
+    adapter.refresh_grids()
+
+    assert adapter._grid_map == {}
+    adapter._bmi.get_portal_spec.assert_not_called()
+
+
+@pytest.mark.unit
+def test_refresh_grids_swallows_exception(adapter):
+    adapter._bmi.get_grids.side_effect = RuntimeError("network down")
+    # Must not raise
+    adapter.refresh_grids()
+    assert adapter._grid_map == {}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  S2Adapter.collect_nodes
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_collect_nodes_inserts_rows(adapter, mock_writer):
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    adapter._phd.run.return_value = _PHD_HOST_OUTPUT
+
+    adapter.collect_nodes()
+
+    adapter._phd.run.assert_called_once_with(["host"], "grid-a")
+    mock_writer.insert.assert_called_once()
+    table, rows = mock_writer.insert.call_args[0]
+    assert table == "s2_nodes"
+    assert len(rows) == 2
+    assert rows[0]["grid_name"] == "grid-a"
+    assert rows[0]["hostname"] == "gpu-node-01"
+
+
+@pytest.mark.unit
+def test_collect_nodes_no_rows_does_not_insert(adapter, mock_writer):
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    adapter._phd.run.return_value = ""  # no phd output
+
+    adapter.collect_nodes()
+
+    mock_writer.insert.assert_not_called()
+
+
+@pytest.mark.unit
+def test_collect_nodes_calls_ensure_grids(mock_writer):
+    """When the grid map is empty, collect_nodes triggers refresh_grids."""
+    with patch("adapters.s2_adapter.requests.Session"):
+        a = S2Adapter(
+            bmi_url="http://bmi.test",
+            phd_bin_template="/opt/{grid_name}/bin/phd",
+            http_proxy_addr="http://squid.test:3128",
+            ssh_jump_host="jump.test",
+            ssh_login_host="login.test",
+            writer=mock_writer,
+            target_grids=["grid-a"],
+        )
+    a._bmi = MagicMock()
+    a._bmi.get_grids.return_value = ["grid-a"]
+    a._bmi.get_portal_spec.return_value = "1@login01"
+    a._phd = MagicMock()
+    a._phd.run.return_value = ""
+
+    a.collect_nodes()
+
+    # grid map got populated lazily via _ensure_grids → refresh_grids
+    assert a._grid_map == {"grid-a": "1@login01"}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  S2Adapter.collect_jobs_active
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_collect_jobs_active_inserts_running_and_queued(adapter, mock_writer):
+    adapter._grid_map = {"grid-a": "6789@login01"}
+
+    def fake_run(args, grid_name):
+        # args == ["list", "-a", flag, "-O", _LIST_FORMAT]
+        if "-r" in args:
+            return _job_line(job_id=1, status="Running", end_ts=0)
+        if "-q" in args:
+            return _job_line(job_id=2, status="Queued", start_ts=0, end_ts=0)
+        return ""
+
+    adapter._phd.run.side_effect = fake_run
+
+    adapter.collect_jobs_active()
+
+    # one insert for Running, one for Queued
+    insert_calls = [c for c in mock_writer.insert.call_args_list if c[0][0] == "s2_jobs"]
+    assert len(insert_calls) == 2
+    job_ids = {c[0][1][0]["job_id"] for c in insert_calls}
+    assert job_ids == {1, 2}
+    # the _LIST_FORMAT output spec was forwarded to phd via -O
+    for call in adapter._phd.run.call_args_list:
+        args = call[0][0]
+        assert args[args.index("-O") + 1] == _LIST_FORMAT
+
+
+@pytest.mark.unit
+def test_collect_jobs_active_runs_vanished_detection_when_ok(adapter, mock_writer):
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    adapter._phd.run.return_value = _job_line(job_id=1, status="Running", end_ts=0)
+    # CH has no Running/Queued rows → nothing to close, but query IS executed
+    mock_writer._client.execute.return_value = []
+
+    adapter.collect_jobs_active()
+
+    assert mock_writer._client.execute.called
+
+
+@pytest.mark.unit
+def test_collect_jobs_active_skips_vanished_detection_on_failure(adapter, mock_writer):
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    # both phd calls raise → collection_ok=False → no vanished detection query
+    adapter._phd.run.side_effect = RuntimeError("ssh broke")
+
+    adapter.collect_jobs_active()
+
+    mock_writer._client.execute.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  S2Adapter._close_vanished_jobs
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_close_vanished_jobs_marks_done(adapter, mock_writer):
+    # CH knows job 999 (submit_ts 111.0) as Running; it's NOT in the active set
+    ch_row = [
+        999,                # job_id
+        "kim",              # user
+        "ai-research",      # project
+        4,                  # gpu_per_node
+        2,                  # num_nodes
+        8,                  # total_gpus
+        None,               # submit_time
+        None,               # start_time
+        111.0,              # submit_ts
+        ["gpu"],            # resources
+        "nodeA[0,1]",       # gpu_indices_raw
+        "[]",               # gpu_allocations
+        "{}",               # properties_json
+    ]
+    mock_writer._client.execute.return_value = [ch_row]
+
+    # active set does NOT contain (999, 111.0) → job is vanished
+    adapter._close_vanished_jobs("grid-a", active_job_keys={(1, 222.0)})
 
     mock_writer.insert.assert_called_once()
     table, rows = mock_writer.insert.call_args[0]
     assert table == "s2_jobs"
     assert len(rows) == 1
+    closed = rows[0]
+    assert closed["job_id"] == 999
+    assert closed["status"] == "Done"
+    assert closed["end_time"] is not None
+    # closed marker present in raw_json
+    assert json.loads(closed["raw_json"])["_closed_by"] == "vanished_detection"
 
 
 @pytest.mark.unit
-def test_collect_nodes_calls_writer(adapter, mock_writer):
-    fake_response = MagicMock()
-    fake_response.json.return_value = {
-        "nodes": [{"name": "node-1", "state": "idle"}]
-    }
-    fake_response.raise_for_status = MagicMock()
-    adapter.session.get.return_value = fake_response
+def test_close_vanished_jobs_keeps_still_active(adapter, mock_writer):
+    ch_row = [
+        999, "kim", "proj", 1, 1, 1, None, None, 111.0,
+        [], "", "[]", "{}",
+    ]
+    mock_writer._client.execute.return_value = [ch_row]
 
-    adapter.collect_nodes()
-
-    mock_writer.insert.assert_called_once()
-    table, _ = mock_writer.insert.call_args[0]
-    assert table == "s2_nodes"
-
-
-@pytest.mark.unit
-def test_collect_jobs_empty_response_does_not_call_writer(adapter, mock_writer):
-    fake_response = MagicMock()
-    fake_response.json.return_value = {"jobs": []}
-    fake_response.raise_for_status = MagicMock()
-    adapter.session.get.return_value = fake_response
-
-    adapter.collect_jobs_running()
+    # job (999, 111.0) IS still active → not closed
+    adapter._close_vanished_jobs("grid-a", active_job_keys={(999, 111.0)})
 
     mock_writer.insert.assert_not_called()
 
 
 @pytest.mark.unit
-def test_collect_jobs_http_error_does_not_raise(adapter, mock_writer):
-    """HTTP errors should be caught and logged, not propagated."""
-    import requests as req_lib
-    adapter.session.get.side_effect = req_lib.exceptions.ConnectionError("refused")
-
-    # Must not raise
-    adapter.collect_jobs_running()
+def test_close_vanished_jobs_empty_ch_does_nothing(adapter, mock_writer):
+    mock_writer._client.execute.return_value = []
+    adapter._close_vanished_jobs("grid-a", active_job_keys=set())
     mock_writer.insert.assert_not_called()
+
+
+@pytest.mark.unit
+def test_close_vanished_jobs_ch_failure_is_swallowed(adapter, mock_writer):
+    mock_writer._client.execute.side_effect = RuntimeError("CH down")
+    # Must not raise, must not insert
+    adapter._close_vanished_jobs("grid-a", active_job_keys=set())
+    mock_writer.insert.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  S2Adapter.collect_jobs_completed
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.unit
+def test_collect_jobs_completed_inserts_and_updates_last_end_ts(adapter, mock_writer):
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    # in-memory last_end_ts already set → window = last - overlap, no CH recovery
+    adapter._last_end_ts = {"grid-a": _TS_END}
+    adapter._phd.run.return_value = _job_line(
+        job_id=7, status="Done", end_ts=_TS_END + 5000,
+    )
+
+    adapter.collect_jobs_completed()
+
+    insert_calls = [c for c in mock_writer.insert.call_args_list if c[0][0] == "s2_jobs"]
+    assert len(insert_calls) == 1
+    rows = insert_calls[0][0][1]
+    assert rows[0]["job_id"] == 7
+    assert rows[0]["status"] == "Done"
+    # last_end_ts advanced to the max end_ts of the collected jobs
+    assert adapter._last_end_ts["grid-a"] == pytest.approx(_TS_END + 5000)
+
+
+@pytest.mark.unit
+def test_collect_jobs_completed_sel_expr_uses_window(adapter, mock_writer):
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    adapter._last_end_ts = {"grid-a": _TS_END}
+    adapter._phd.run.return_value = ""
+
+    adapter.collect_jobs_completed()
+
+    args = adapter._phd.run.call_args[0][0]
+    # ["list", "-a", "-sel", sel_expr, "-O", _LIST_FORMAT]
+    assert "-sel" in args
+    sel_expr = args[args.index("-sel") + 1]
+    assert "status==Done" in sel_expr
+    assert "end_time >" in sel_expr
+    # window = last_end_ts - 600s overlap
+    assert str(_TS_END - 600) in sel_expr
+
+
+@pytest.mark.unit
+def test_collect_jobs_completed_recovers_last_end_ts_from_ch(adapter, mock_writer):
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    # no in-memory ts → _get_last_end_ts queries CH (returns submit_ts max)
+    mock_writer._client.execute.return_value = [[_TS_END]]
+    adapter._phd.run.return_value = ""
+
+    adapter.collect_jobs_completed()
+
+    # CH recovery happened
+    assert mock_writer._client.execute.called
+    # window derived from recovered ts (not the 7-day fallback)
+    args = adapter._phd.run.call_args[0][0]
+    sel_expr = args[args.index("-sel") + 1]
+    assert str(_TS_END - 600) in sel_expr

--- a/src/metadata-collector/tests/test_s2_adapter.py
+++ b/src/metadata-collector/tests/test_s2_adapter.py
@@ -27,6 +27,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from adapters.s2_adapter import (  # noqa: E402
     _LIST_FORMAT,
+    PhdCommandError,
     S2Adapter,
     _BMIClient,
     _float,
@@ -456,7 +457,7 @@ def test_ssh_phd_runner_returns_stdout():
 
 
 @pytest.mark.unit
-def test_ssh_phd_runner_nonzero_returns_empty():
+def test_ssh_phd_runner_nonzero_raises():
     runner = _SSHPHDRunner(
         phd_bin_template="phd",
         jump_host="jump.test",
@@ -464,11 +465,12 @@ def test_ssh_phd_runner_nonzero_returns_empty():
     )
     completed = MagicMock(returncode=1, stdout="partial", stderr="boom")
     with patch("adapters.s2_adapter.subprocess.run", return_value=completed):
-        assert runner.run(["host"], "grid-a") == ""
+        with pytest.raises(PhdCommandError, match="rc=1"):
+            runner.run(["host"], "grid-a")
 
 
 @pytest.mark.unit
-def test_ssh_phd_runner_timeout_returns_empty():
+def test_ssh_phd_runner_timeout_raises():
     import subprocess as _sp
 
     runner = _SSHPHDRunner(
@@ -480,7 +482,8 @@ def test_ssh_phd_runner_timeout_returns_empty():
         "adapters.s2_adapter.subprocess.run",
         side_effect=_sp.TimeoutExpired(cmd="ssh", timeout=120),
     ):
-        assert runner.run(["host"], "grid-a") == ""
+        with pytest.raises(PhdCommandError, match="timeout"):
+            runner.run(["host"], "grid-a")
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -491,9 +494,8 @@ def test_ssh_phd_runner_timeout_returns_empty():
 def mock_writer():
     w = MagicMock()
     w.insert = MagicMock()
-    # writer._client.execute used for CH recovery / vanished detection
-    w._client = MagicMock()
-    w._client.execute = MagicMock(return_value=[])
+    # writer.query used for CH recovery / vanished detection
+    w.query = MagicMock(return_value=[])
     return w
 
 
@@ -541,6 +543,17 @@ def test_refresh_grids_skips_target_not_in_bmi(adapter):
 
     assert adapter._grid_map == {}
     adapter._bmi.get_portal_spec.assert_not_called()
+
+
+@pytest.mark.unit
+def test_refresh_grids_keeps_grid_without_portal_spec(adapter):
+    # A grid with no portal pnodes must still be collected
+    adapter._bmi.get_grids.return_value = ["grid-a"]
+    adapter._bmi.get_portal_spec.return_value = ""
+
+    adapter.refresh_grids()
+
+    assert "grid-a" in adapter._grid_map
 
 
 @pytest.mark.unit
@@ -642,11 +655,11 @@ def test_collect_jobs_active_runs_vanished_detection_when_ok(adapter, mock_write
     adapter._grid_map = {"grid-a": "6789@login01"}
     adapter._phd.run.return_value = _job_line(job_id=1, status="Running", end_ts=0)
     # CH has no Running/Queued rows → nothing to close, but query IS executed
-    mock_writer._client.execute.return_value = []
+    mock_writer.query.return_value = []
 
     adapter.collect_jobs_active()
 
-    assert mock_writer._client.execute.called
+    assert mock_writer.query.called
 
 
 @pytest.mark.unit
@@ -657,18 +670,43 @@ def test_collect_jobs_active_skips_vanished_detection_on_failure(adapter, mock_w
 
     adapter.collect_jobs_active()
 
-    mock_writer._client.execute.assert_not_called()
+    mock_writer.query.assert_not_called()
+
+
+@pytest.mark.unit
+def test_collect_jobs_active_ssh_rc_failure_does_not_mass_close(adapter, mock_writer):
+    """Regression: an ssh non-zero exit must NOT look like 'no active jobs'.
+
+    With a real _SSHPHDRunner and ssh exiting rc=1, the run must raise so
+    collection_ok=False — otherwise every Running/Queued job in CH would be
+    closed by vanished detection.
+    """
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    adapter._phd = _SSHPHDRunner(
+        phd_bin_template="/opt/{grid_name}/bin/phd",
+        jump_host="jump.test",
+        login_host="login.test",
+    )
+    # CH holds an active job that would be wrongly closed
+    mock_writer.query.return_value = [_ch_active_row(status="Running")]
+
+    failed = MagicMock(returncode=255, stdout="", stderr="connection refused")
+    with patch("adapters.s2_adapter.subprocess.run", return_value=failed):
+        adapter.collect_jobs_active()
+
+    # no vanished detection ran, nothing was closed
+    mock_writer.query.assert_not_called()
+    mock_writer.insert.assert_not_called()
 
 
 # ═══════════════════════════════════════════════════════════════════════
 #  S2Adapter._close_vanished_jobs
 # ═══════════════════════════════════════════════════════════════════════
 
-@pytest.mark.unit
-def test_close_vanished_jobs_marks_done(adapter, mock_writer):
-    # CH knows job 999 (submit_ts 111.0) as Running; it's NOT in the active set
-    ch_row = [
-        999,                # job_id
+def _ch_active_row(job_id=999, submit_ts=111.0, status="Running"):
+    """A row in the shape returned by the _close_vanished_jobs SELECT."""
+    return [
+        job_id,             # job_id
         "kim",              # user
         "ai-research",      # project
         4,                  # gpu_per_node
@@ -676,13 +714,19 @@ def test_close_vanished_jobs_marks_done(adapter, mock_writer):
         8,                  # total_gpus
         None,               # submit_time
         None,               # start_time
-        111.0,              # submit_ts
+        submit_ts,          # submit_ts
         ["gpu"],            # resources
         "nodeA[0,1]",       # gpu_indices_raw
         "[]",               # gpu_allocations
         "{}",               # properties_json
+        status,             # status
     ]
-    mock_writer._client.execute.return_value = [ch_row]
+
+
+@pytest.mark.unit
+def test_close_vanished_jobs_marks_running_done(adapter, mock_writer):
+    # CH knows job 999 (submit_ts 111.0) as Running; it's NOT in the active set
+    mock_writer.query.return_value = [_ch_active_row(status="Running")]
 
     # active set does NOT contain (999, 111.0) → job is vanished
     adapter._close_vanished_jobs("grid-a", active_job_keys={(1, 222.0)})
@@ -700,12 +744,33 @@ def test_close_vanished_jobs_marks_done(adapter, mock_writer):
 
 
 @pytest.mark.unit
+def test_close_vanished_queued_marked_stopped(adapter, mock_writer):
+    # A vanished Queued job never ran → must NOT be counted as completed
+    mock_writer.query.return_value = [_ch_active_row(status="Queued")]
+
+    adapter._close_vanished_jobs("grid-a", active_job_keys=set())
+
+    table, rows = mock_writer.insert.call_args[0]
+    assert rows[0]["status"] == "Stopped"
+    assert json.loads(rows[0]["raw_json"])["prior_status"] == "Queued"
+
+
+@pytest.mark.unit
+def test_close_vanished_jobs_select_pins_column_order(adapter, mock_writer):
+    """The row indices used to build closed rows depend on this column order."""
+    mock_writer.query.return_value = []
+
+    adapter._close_vanished_jobs("grid-a", active_job_keys=set())
+
+    sql = mock_writer.query.call_args[0][0]
+    cols_part = sql.split("FROM")[0]
+    assert cols_part.startswith("SELECT job_id, user, project, gpu_per_node, num_nodes,")
+    assert cols_part.rstrip().endswith("properties_json, status")
+
+
+@pytest.mark.unit
 def test_close_vanished_jobs_keeps_still_active(adapter, mock_writer):
-    ch_row = [
-        999, "kim", "proj", 1, 1, 1, None, None, 111.0,
-        [], "", "[]", "{}",
-    ]
-    mock_writer._client.execute.return_value = [ch_row]
+    mock_writer.query.return_value = [_ch_active_row(job_id=999, submit_ts=111.0)]
 
     # job (999, 111.0) IS still active → not closed
     adapter._close_vanished_jobs("grid-a", active_job_keys={(999, 111.0)})
@@ -715,14 +780,14 @@ def test_close_vanished_jobs_keeps_still_active(adapter, mock_writer):
 
 @pytest.mark.unit
 def test_close_vanished_jobs_empty_ch_does_nothing(adapter, mock_writer):
-    mock_writer._client.execute.return_value = []
+    mock_writer.query.return_value = []
     adapter._close_vanished_jobs("grid-a", active_job_keys=set())
     mock_writer.insert.assert_not_called()
 
 
 @pytest.mark.unit
 def test_close_vanished_jobs_ch_failure_is_swallowed(adapter, mock_writer):
-    mock_writer._client.execute.side_effect = RuntimeError("CH down")
+    mock_writer.query.side_effect = RuntimeError("CH down")
     # Must not raise, must not insert
     adapter._close_vanished_jobs("grid-a", active_job_keys=set())
     mock_writer.insert.assert_not_called()
@@ -748,8 +813,26 @@ def test_collect_jobs_completed_inserts_and_updates_last_end_ts(adapter, mock_wr
     rows = insert_calls[0][0][1]
     assert rows[0]["job_id"] == 7
     assert rows[0]["status"] == "Done"
+    # rows are persisted before the watermark advances
+    mock_writer.flush.assert_called_once()
     # last_end_ts advanced to the max end_ts of the collected jobs
     assert adapter._last_end_ts["grid-a"] == pytest.approx(_TS_END + 5000)
+
+
+@pytest.mark.unit
+def test_collect_jobs_completed_failed_flush_keeps_watermark(adapter, mock_writer):
+    """If rows could not be persisted, the watermark must not advance —
+    otherwise a crash would permanently skip the buffered jobs."""
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    adapter._last_end_ts = {"grid-a": _TS_END}
+    adapter._phd.run.return_value = _job_line(
+        job_id=7, status="Done", end_ts=_TS_END + 5000,
+    )
+    mock_writer.flush.return_value = False
+
+    adapter.collect_jobs_completed()
+
+    assert adapter._last_end_ts["grid-a"] == pytest.approx(_TS_END)
 
 
 @pytest.mark.unit
@@ -773,15 +856,37 @@ def test_collect_jobs_completed_sel_expr_uses_window(adapter, mock_writer):
 @pytest.mark.unit
 def test_collect_jobs_completed_recovers_last_end_ts_from_ch(adapter, mock_writer):
     adapter._grid_map = {"grid-a": "6789@login01"}
-    # no in-memory ts → _get_last_end_ts queries CH (returns submit_ts max)
-    mock_writer._client.execute.return_value = [[_TS_END]]
+    # no in-memory ts → _get_last_end_ts queries CH (returns max end_time)
+    mock_writer.query.return_value = [[_TS_END]]
     adapter._phd.run.return_value = ""
 
     adapter.collect_jobs_completed()
 
     # CH recovery happened
-    assert mock_writer._client.execute.called
+    assert mock_writer.query.called
     # window derived from recovered ts (not the 7-day fallback)
     args = adapter._phd.run.call_args[0][0]
     sel_expr = args[args.index("-sel") + 1]
     assert str(_TS_END - 600) in sel_expr
+
+
+@pytest.mark.unit
+def test_collect_jobs_completed_initial_lookback_window(adapter, mock_writer):
+    """First collection with failed CH recovery must be bounded to ~7 days.
+
+    An unbounded window (end_time > 0) would scan every completed job ever
+    and OOM the pod.
+    """
+    import time as _time
+
+    adapter._grid_map = {"grid-a": "6789@login01"}
+    # no in-memory ts and CH recovery fails → last_ts = 0.0 → 7-day fallback
+    mock_writer.query.side_effect = RuntimeError("CH down")
+    adapter._phd.run.return_value = ""
+
+    adapter.collect_jobs_completed()
+
+    args = adapter._phd.run.call_args[0][0]
+    sel_expr = args[args.index("-sel") + 1]
+    window_ts = float(sel_expr.split("end_time > ")[1])
+    assert window_ts == pytest.approx(_time.time() - 86400 * 7, abs=120)

--- a/src/metadata-collector/tests/test_writer.py
+++ b/src/metadata-collector/tests/test_writer.py
@@ -78,7 +78,7 @@ def test_insert_multiple_batches(writer):
 @pytest.mark.unit
 def test_flush_sends_pending_rows(writer):
     writer.insert("s2_jobs", [{"job_id": "1"}])
-    writer.flush()
+    assert writer.flush() is True
     writer._client.execute.assert_called_once()
     # Buffer should be empty after flush
     assert writer._buffers.get("s2_jobs", []) == []
@@ -125,7 +125,7 @@ def test_flush_failure_rebuffers_rows(writer):
     writer._client.execute.side_effect = Exception("connection lost")
 
     writer.insert("s2_jobs", [{"job_id": "x"}])
-    writer.flush()
+    assert writer.flush() is False
 
     # Row should be back in buffer
     assert len(writer._buffers.get("s2_jobs", [])) == 1
@@ -139,3 +139,28 @@ def test_insert_table_name_in_execute_call(writer):
 
     call_args = writer._client.execute.call_args[0]
     assert "s2_jobs" in call_args[0]
+
+
+# ─── query() ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_query_runs_on_shared_client(writer):
+    writer._client.execute.return_value = [[42]]
+    result = writer.query("SELECT 42", {"k": "v"})
+    assert result == [[42]]
+    writer._client.execute.assert_called_once_with("SELECT 42", {"k": "v"})
+
+
+@pytest.mark.unit
+def test_query_flushes_buffered_rows_first(writer):
+    """Read-back logic must see its own buffered writes."""
+    writer.insert("s2_jobs", [{"job_id": "1"}])
+
+    writer.query("SELECT count() FROM s2_jobs", None)
+
+    # first call is the buffered INSERT, second is the SELECT
+    calls = [c[0][0] for c in writer._client.execute.call_args_list]
+    assert len(calls) == 2
+    assert "INSERT INTO s2_jobs" in calls[0]
+    assert calls[1] == "SELECT count() FROM s2_jobs"
+    assert writer._buffers.get("s2_jobs", []) == []

--- a/src/metadata-collector/writer/clickhouse_writer.py
+++ b/src/metadata-collector/writer/clickhouse_writer.py
@@ -54,20 +54,37 @@ class ClickHouseWriter:
             if len(buf) >= self._batch_size:
                 self._flush_table(table)
 
-    def flush(self):
+    def flush(self) -> bool:
+        """Flush all buffers. Returns True only if every table flushed."""
+        with self._lock:
+            ok = True
+            for table in list(self._buffers.keys()):
+                ok = self._flush_table(table) and ok
+            return ok
+
+    def query(self, sql: str, params: dict = None):
+        """Run a read query, serialized with writes on the shared client.
+
+        clickhouse_driver.Client wraps a single socket and is not thread-safe,
+        so every read must hold the same lock as insert/flush. Buffered rows
+        are flushed first (best-effort) so read-back logic sees its own writes.
+        """
         with self._lock:
             for table in list(self._buffers.keys()):
                 self._flush_table(table)
+            return self._client.execute(sql, params)
 
-    def _flush_table(self, table: str):
-        """Must be called with self._lock held."""
+    def _flush_table(self, table: str) -> bool:
+        """Must be called with self._lock held. Returns True on success."""
         rows = self._buffers.pop(table, [])
         if not rows:
-            return
+            return True
         try:
             self._client.execute(f"INSERT INTO {table} VALUES", rows)
             logger.debug("Flushed %d rows to %s", len(rows), table)
+            return True
         except Exception as e:
             logger.error("Failed to flush %d rows to %s: %s", len(rows), table, e)
             # Re-buffer on failure to avoid data loss
             self._buffers.setdefault(table, []).extend(rows)
+            return False

--- a/tests/component/test_clickhouse.py
+++ b/tests/component/test_clickhouse.py
@@ -38,17 +38,20 @@ TABLE_COLUMNS = {
     },
     "s2_jobs": {
         "collected_at": "DateTime",
-        "job_id": "String",
-        "user_id": "String",
+        "grid_name": "String",
+        "job_id": "UInt64",
+        "user": "String",
         "status": "String",
-        "node_list": "Array",
-        "gpu_indices": "Array",
+        "submit_ts": "Float64",
+        "resources": "Array",
+        "gpu_allocations": "String",
     },
     "s2_nodes": {
-        "node_id": "String",
-        "status": "String",
-        "gpu_total": "UInt",
-        "gpu_allocated": "UInt",
+        "grid_name": "String",
+        "hostname": "String",
+        "op_status": "String",
+        "cores_avail": "UInt",
+        "cores_used": "UInt",
     },
     "vmware_vm_inventory": {
         "vm_uuid": "String",
@@ -168,10 +171,12 @@ def test_insert_and_select_s2_jobs():
         params={
             "query": (
                 "INSERT INTO gpu_monitoring.s2_jobs "
-                "(collected_at, job_id, job_name, user_id, team, queue, status, "
-                " node_list, gpu_count, gpu_indices, cpu_count, memory_mb, metadata) "
-                "VALUES (now(), 'test-job-1', 'test-job', 'test-user', 'test-team', "
-                "        'default', 'running', ['node-1'], 2, [0, 1], 8, 16384, '{}')"
+                "(collected_at, grid_name, job_id, user, status, project, "
+                " gpu_per_node, num_nodes, total_gpus, submit_ts, resources, "
+                " gpu_indices_raw, gpu_allocations, properties_json, raw_json) "
+                "VALUES (now(), 'test-grid', 990001, 'test-user', 'Running', "
+                "        'test-project', 4, 2, 8, 1700000000.0, ['gpu'], "
+                "        'node-1[0,1]', '[]', '{}', '{}')"
             )
         },
         timeout=5,
@@ -180,7 +185,7 @@ def test_insert_and_select_s2_jobs():
     r = requests.post(
         CLICKHOUSE_URL,
         params={
-            "query": "SELECT count() FROM gpu_monitoring.s2_jobs WHERE job_id='test-job-1'"
+            "query": "SELECT count() FROM gpu_monitoring.s2_jobs WHERE job_id=990001"
         },
         timeout=5,
     )


### PR DESCRIPTION
## Summary
Ports an external contribution (jeonghma's S2 batch-scheduler adapter) into the `metadata-collector` component, **sanitized of all corp-specific data**. S2 metadata is collected via the BMI REST API + SSH `phd` commands through a jump host. Real connection values are supplied by the private `gpu-mon-corp` overlay, per the 2-repo design.

## Changes by layer
**Python (`src/metadata-collector/`)**
- `adapters/s2_adapter.py`: BMI grid discovery, node/job collection (Running/Queued full snapshot + Done/Failed/Stopped incremental by `end_time`), vanished-job close detection. Reads now use the writer's configured database (dropped a hardcoded `gpu_metadata.` prefix) and the correct `end_time` watermark. Comments translated to English.
- `main.py`: wire intervals; default args carry no real endpoints.
- `config.yaml`: local-dev example only (`s2.enabled: false`, `*.example.internal` placeholders).
- `Dockerfile`: drop the internal CA cert; keep `openssh-client` (the ssh ProxyCommand needs it).
- `tests/test_s2_adapter.py`: rewritten for the new API.

**Helm chart (`charts/metadata-collector/`)**
- Expose `config.sources.s2.*` (`bmiUrl`, `httpProxyAddr`, `phdBinTemplate`, `ssh.*`, `targetGrids`, `intervals.*`), rendered (snake_case) into the ConfigMap only when `s2.enabled`.
- `CLICKHOUSE_PASSWORD` from `existingSecrets.clickhousePassword` (no plaintext); configurable `imagePullSecrets`; set `MC_CONFIG_PATH` so the rendered ConfigMap is used.
- Generic image `ghcr.io/yoonsungnam/gpu-mon/metadata-collector`; `Chart.yaml` description de-companied.

**Schemas (`schemas/`)**
- Rewrite `s2_jobs.sql` / `s2_nodes.sql` to match the new adapter row shapes (`ReplacingMergeTree`); unify on the `gpu_monitoring` database. README table updated.

## Test evidence
- `pytest` (src/metadata-collector): **75 passed** (50 new S2 tests; subprocess + requests mocked).
- `helm template` default + s2-enabled: valid YAML with the expected snake_case keys; `helm unittest`: **12 passed**; `helm lint`: clean.
- Schema↔adapter column consistency: exact match (18/18 jobs, 17/17 nodes), incl. the vanished-close row.
- Leak audit (3 lenses + sweep): no IPs/hostnames/registry/company name/Hangul in added lines.

## Companion (real values)
Private overlay `environments/corp/metadata-collector.yaml` in `gpu-mon-corp` (`feat/metadata-collector-s2-config`). **This chart change is its prerequisite.**

## Known follow-ups (non-blocking)
- `schemas/s2_pools.sql` / `s2_projects.sql` have no writer in the new adapter (pool/project collection was dropped) — left in place + flagged in the README; decide to remove or re-add collection.
- `s2_jobs` partitions by `toYYYYMM(collected_at)`; ReplacingMergeTree dedup is within-partition, so a job spanning a month boundary can briefly show two versions under `FINAL`. Low impact for this data volume.
- VMware adapter unchanged / only partially wired (vcenter URL not templated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)