### PR TITLE
feat(clickhouse-keeper): add PodDisruptionBudget to protect raft quorum on small clusters

### DIFF
--- a/charts/clickhouse-keeper/Chart.yaml
+++ b/charts/clickhouse-keeper/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: clickhouse-keeper
 description: ClickHouse Keeper — ZooKeeper-compatible coordination service for ClickHouse replication
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "24.8"

--- a/charts/clickhouse-keeper/templates/poddisruptionbudget.yaml
+++ b/charts/clickhouse-keeper/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "clickhouse-keeper.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse-keeper.labels" . | nindent 4 }}
+spec:
+  # Cap how many keeper pods a *voluntary* disruption (node drain, rolling node
+  # upgrade) can take down at once. With soft anti-affinity on a 2-node cluster the
+  # 3 replicas pack as 2+1, so without this a drain of the 2-pod node would evict
+  # two replicas together and break the raft quorum. maxUnavailable: 1 keeps a
+  # 2-of-3 majority during drains.
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "clickhouse-keeper.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/clickhouse-keeper/tests/poddisruptionbudget_test.yaml
+++ b/charts/clickhouse-keeper/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,35 @@
+suite: clickhouse-keeper poddisruptionbudget
+templates:
+  - templates/poddisruptionbudget.yaml
+
+tests:
+  - it: renders a PDB by default that keeps a raft majority during drains
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: metadata.name
+          value: clickhouse-keeper
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - isNotEmpty:
+          path: spec.selector.matchLabels
+
+  - it: is not rendered when disabled
+    set:
+      podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: honours a custom maxUnavailable
+    set:
+      podDisruptionBudget.maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2

--- a/charts/clickhouse-keeper/values.yaml
+++ b/charts/clickhouse-keeper/values.yaml
@@ -23,3 +23,15 @@ resources:
 # (a non-empty value takes precedence over this toggle).
 podAntiAffinity: true
 affinity: {}
+
+# PodDisruptionBudget guards the raft quorum against *voluntary* disruptions
+# (node drains, rolling node upgrades). On a small (1-2 node) cluster the soft
+# anti-affinity above packs replicas onto fewer nodes (e.g. 2+1 on two nodes), so
+# without a PDB a single `kubectl drain` can evict two keeper pods at once and
+# break the quorum. maxUnavailable: 1 keeps a 2-of-3 majority during drains.
+# NOTE: a PDB only blocks *voluntary* evictions — it cannot protect against an
+# *unplanned* loss of the node hosting two pods. True node-failure HA needs a
+# third schedulable node (and ideally hard anti-affinity via `affinity` above).
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1


### PR DESCRIPTION
## Summary
Adds a configurable `PodDisruptionBudget` to the `clickhouse-keeper` chart so a
voluntary disruption (node drain, rolling node upgrade) cannot break the raft
quorum on small clusters.

## Why
The chart uses **soft** (preferred) pod anti-affinity, so on a 1–2 node cluster
the 3 keeper replicas pack onto fewer nodes (e.g. **2+1** on two nodes). With no
PDB, a single `kubectl drain` of the 2-pod node evicts **two** replicas at once
and breaks the 2-of-3 raft majority. `maxUnavailable: 1` keeps a majority during
drains.

> Honest limit: a PDB only blocks **voluntary** evictions. It cannot protect
> against an **unplanned** loss of the node hosting two pods — true node-failure
> HA still needs a third schedulable node (and ideally hard anti-affinity via
> `affinity`). Low-stakes today since current schemas are non-Replicated, so
> keeper backs only `ON CLUSTER` DDL.

## Changes
- `templates/poddisruptionbudget.yaml` — `policy/v1` PDB, gated by `podDisruptionBudget.enabled`
- `values.yaml` — `podDisruptionBudget.{enabled: true, maxUnavailable: 1}` (documented caveat)
- `tests/poddisruptionbudget_test.yaml` — default render / disabled / custom `maxUnavailable`
- Chart `0.1.0 → 0.2.0`

## Test evidence
`helm unittest charts/clickhouse-keeper` → **23 passed, 4 suites**. Verified
`helm template` renders the PDB by default and omits it when disabled.

## Related
- Keeper chart + helmfile wiring: #66 (merged to dev)
- Keeper migration runbook: #68 (docs; node count unchanged — keep `replicaCount: 3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)