### PR TITLE
ci: guard against replicasCount>1 with non-replicated schemas

### DIFF
--- a/.github/workflows/replication-topology.yml
+++ b/.github/workflows/replication-topology.yml
@@ -1,0 +1,42 @@
+---
+# Replication-topology guard — fails CI when an environment declares
+# clickhouse.cluster.layout.replicasCount > 1 while any schema in schemas/*.sql
+# uses a non-replicated MergeTree-family engine (replicasCount > 1 gives real HA
+# only with Replicated* engines). See scripts/validate_replication_topology.py.
+
+name: Replication Topology Guard
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  guard:
+    name: replication-topology guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Guard deployable environments (hard fail)
+        run: python3 scripts/validate_replication_topology.py homelab
+
+      - name: Lint corp.example template (advisory)
+        # corp.example is an aspirational template; surface the mismatch without
+        # blocking. Flip to a hard check once corp picks replicasCount=1 or
+        # converts the schemas to Replicated* engines.
+        env:
+          WARN_ONLY: "1"
+        run: python3 scripts/validate_replication_topology.py corp.example
+
+      - name: Unit-test the guard
+        run: |
+          pip install pytest
+          pytest scripts/tests/test_validate_replication_topology.py -v

--- a/scripts/tests/test_validate_replication_topology.py
+++ b/scripts/tests/test_validate_replication_topology.py
@@ -1,0 +1,117 @@
+"""Tests for scripts/validate_replication_topology.py.
+
+Covers the red-team cases that broke the first (awk) draft: multiline ENGINE,
+case-insensitive keywords, multiple statements per line, block comments,
+path-scoped replicasCount, quoted/odd values, and the empty-schemas edge.
+"""
+import importlib.util
+import os
+
+import pytest
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "validate_replication_topology.py")
+_spec = importlib.util.spec_from_file_location("vrt", _SCRIPT)
+vrt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(vrt)
+
+
+# ── engine detection ────────────────────────────────────────────────────────
+@pytest.mark.parametrize("sql", [
+    "CREATE TABLE t (a Int32) ENGINE = MergeTree() ORDER BY a;",
+    "CREATE TABLE t (a Int32) ENGINE=MergeTree ORDER BY a;",            # no parens
+    "CREATE TABLE t (a Int32) ENGINE\n  =\n  MergeTree() ORDER BY a;",  # multiline
+    "create table t (a Int32) engine = mergetree() order by a;",        # lowercase
+    "CREATE TABLE t (a Int32) Engine = MergeTree() ORDER BY a;",        # mixed case
+    "CREATE TABLE t (a Int32) ENGINE = ReplacingMergeTree(v) ORDER BY a;",
+    "CREATE TABLE t (a Int32) ENGINE = SummingMergeTree() ORDER BY a;",
+])
+def test_flags_non_replicated_mergetree(sql):
+    assert vrt.non_replicated_tables(sql), f"should flag: {sql!r}"
+
+
+@pytest.mark.parametrize("sql", [
+    "CREATE TABLE t (a Int32) ENGINE = ReplicatedMergeTree('/p','{replica}') ORDER BY a;",
+    "CREATE TABLE t (a Int32) ENGINE = ReplicatedReplacingMergeTree('/p','{replica}',v) ORDER BY a;",
+    "CREATE TABLE t (a Int32) ENGINE = Distributed(c, db, t, rand());",
+    "CREATE TABLE t (a Int32) ENGINE = Null;",
+    "CREATE TABLE t (a Int32) ENGINE = Memory;",
+    "CREATE TABLE t (k String, v String) ENGINE = Kafka;",
+    "-- CREATE TABLE t (a Int32) ENGINE = MergeTree();",               # line comment
+    "/* ENGINE = MergeTree */ CREATE TABLE t (a Int32) "
+    "ENGINE = ReplicatedMergeTree('/p','{r}') ORDER BY a;",             # block comment
+])
+def test_does_not_flag(sql):
+    assert vrt.non_replicated_tables(sql) == [], f"should NOT flag: {sql!r}"
+
+
+def test_two_statements_one_line_plain_first():
+    sql = ("CREATE TABLE bad (a Int32) ENGINE = MergeTree(); "
+           "CREATE TABLE good (a Int32) ENGINE = ReplicatedMergeTree('/p','{r}');")
+    flagged = vrt.non_replicated_tables(sql)
+    assert [n for n, _ in flagged] == ["bad"]
+
+
+def test_mixed_file_reports_only_plain_with_names():
+    sql = (
+        "CREATE TABLE db.plain (a Int32) ENGINE = ReplacingMergeTree(a) ORDER BY a;\n"
+        "CREATE TABLE db.repl  (a Int32) ENGINE = ReplicatedMergeTree('/p','{r}') ORDER BY a;\n"
+    )
+    flagged = vrt.non_replicated_tables(sql)
+    assert flagged == [("db.plain", "ReplacingMergeTree")]
+
+
+# ── replicasCount parsing (path-scoped) ─────────────────────────────────────
+def _write(tmp_path, body):
+    p = tmp_path / "clickhouse.yaml"
+    p.write_text(body)
+    return str(p)
+
+
+def test_replicas_basic(tmp_path):
+    f = _write(tmp_path, "clickhouse:\n  cluster:\n    layout:\n      replicasCount: 2\n")
+    assert vrt.effective_replicas(f) == 2
+
+
+def test_replicas_default_when_absent(tmp_path):
+    f = _write(tmp_path, "clickhouse:\n  cluster:\n    layout:\n      shardsCount: 2\n")
+    assert vrt.effective_replicas(f) == 1
+
+
+def test_replicas_inline_comment(tmp_path):
+    f = _write(tmp_path, "clickhouse:\n  cluster:\n    layout:\n      replicasCount: 2  # HA\n")
+    assert vrt.effective_replicas(f) == 2
+
+
+def test_replicas_quoted_value(tmp_path):
+    f = _write(tmp_path, 'clickhouse:\n  cluster:\n    layout:\n      replicasCount: "2"\n')
+    assert vrt.effective_replicas(f) == 2
+
+
+def test_replicas_leading_zero(tmp_path):
+    f = _write(tmp_path, "clickhouse:\n  cluster:\n    layout:\n      replicasCount: 08\n")
+    assert vrt.effective_replicas(f) == 8
+
+
+def test_replicas_ignores_decoy_outside_layout(tmp_path):
+    # A sibling block lists replicasCount: 1 FIRST; the real layout value is 2.
+    f = _write(tmp_path,
+               "somecomponent:\n  replicasCount: 1\n"
+               "clickhouse:\n  cluster:\n    layout:\n      replicasCount: 2\n")
+    assert vrt.effective_replicas(f) == 2
+
+
+def test_replicas_ignores_comment_only_key(tmp_path):
+    f = _write(tmp_path,
+               "clickhouse:\n  cluster:\n    layout:\n"
+               "      # replicasCount: 2 (planned)\n      replicasCount: 1\n")
+    assert vrt.effective_replicas(f) == 1
+
+
+# ── scan + missing/empty handling ───────────────────────────────────────────
+def test_scan_empty_dir_no_crash(tmp_path):
+    assert vrt.scan_schemas(str(tmp_path)) == []
+
+
+def test_scan_dir_without_sql(tmp_path):
+    (tmp_path / "readme.md").write_text("not sql")
+    assert vrt.scan_schemas(str(tmp_path)) == []

--- a/scripts/tests/test_validate_replication_topology.py
+++ b/scripts/tests/test_validate_replication_topology.py
@@ -115,3 +115,15 @@ def test_scan_empty_dir_no_crash(tmp_path):
 def test_scan_dir_without_sql(tmp_path):
     (tmp_path / "readme.md").write_text("not sql")
     assert vrt.scan_schemas(str(tmp_path)) == []
+
+
+# ── missing values file (soft-fail guard) ───────────────────────────────────
+def test_main_missing_env_hard_fails(monkeypatch):
+    # A deployable env whose values file is absent must fail, not silently pass.
+    monkeypatch.delenv("WARN_ONLY", raising=False)
+    assert vrt.main(["prog", "does-not-exist-env"]) == 1
+
+
+def test_main_missing_env_warn_only_skips(monkeypatch):
+    monkeypatch.setenv("WARN_ONLY", "1")
+    assert vrt.main(["prog", "does-not-exist-env"]) == 0

--- a/scripts/validate_replication_topology.py
+++ b/scripts/validate_replication_topology.py
@@ -18,8 +18,10 @@ Resolves the cluster layout from ``environments/<env>/clickhouse.yaml``, falling
 template, e.g. ``... corp.example``).
 
 Env vars:
-    WARN_ONLY=1   Report the mismatch as a warning and exit 0 (for an aspirational
-                  template that intentionally precedes a schema migration).
+    WARN_ONLY=1   Report a mismatch (or a missing values file) as a warning and exit 0
+                  (for an aspirational template that intentionally precedes a schema
+                  migration). Without it, a missing values file for the requested
+                  environment is a hard failure.
 
 Stdlib only — no PyYAML / yq required.
 """
@@ -133,9 +135,18 @@ def main(argv: list[str]) -> int:
 
     values_file = _resolve_values_file(env)
     if values_file is None:
-        print(f"SKIP: no clickhouse values for '{env}' "
-              f"(looked for environments/{env}/clickhouse.yaml[.example]).")
-        return 0
+        msg = (f"no clickhouse values for '{env}' "
+               f"(looked for environments/{env}/clickhouse.yaml[.example]).")
+        if warn_only:
+            print(f"SKIP (WARN_ONLY=1): {msg}")
+            return 0
+        # A guard that silently passes when its input disappears is a soft-fail:
+        # a renamed/removed values file would mask a real misconfiguration. Treat a
+        # missing file for a deployable environment as an error.
+        print(f"FAILED: {msg}")
+        print("A deployable environment must ship a clickhouse values file for the "
+              "guard to check it. Set WARN_ONLY=1 to downgrade this to a skip.")
+        return 1
 
     replicas = effective_replicas(values_file)
     rel = os.path.relpath(values_file, REPO_ROOT)

--- a/scripts/validate_replication_topology.py
+++ b/scripts/validate_replication_topology.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""validate_replication_topology.py — Guard against the "replicated topology, but
+non-replicated tables" mismatch.
+
+A ClickHouse cluster with ``layout.replicasCount > 1`` only provides real data HA if
+its tables use a ``Replicated*`` engine (ReplicatedMergeTree, ReplicatedReplacingMergeTree,
+...). With a plain MergeTree/ReplacingMergeTree the operator just provisions N replica
+pods that hold INDEPENDENT, diverging copies — ``replicasCount > 1`` then buys nothing
+but a false sense of HA. This guard fails when an environment declares
+``replicasCount > 1`` while any schema in ``schemas/*.sql`` uses a non-replicated
+MergeTree-family engine.
+
+Usage:
+    python3 scripts/validate_replication_topology.py [environment]   # default: homelab
+
+Resolves the cluster layout from ``environments/<env>/clickhouse.yaml``, falling back to
+``environments/<env>/clickhouse.yaml.example`` (so it also lints the corp.example
+template, e.g. ``... corp.example``).
+
+Env vars:
+    WARN_ONLY=1   Report the mismatch as a warning and exit 0 (for an aspirational
+                  template that intentionally precedes a schema migration).
+
+Stdlib only — no PyYAML / yq required.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# replicasCount lives at clickhouse.cluster.layout.replicasCount.
+_LAYOUT_PATH = ("clickhouse", "cluster", "layout")
+_KEY_RE = re.compile(r"^(\s*)([A-Za-z0-9_]+)\s*:\s*(.*?)\s*$")
+
+# A CREATE TABLE/VIEW statement's target name (best-effort; quoted names with spaces
+# are reported partially, which does not affect detection).
+_CREATE_RE = re.compile(
+    r"create\s+(?:or\s+replace\s+)?(?:materialized\s+|temporary\s+)?(?:table|view)\s+"
+    r"(?:if\s+not\s+exists\s+)?([`\"\w.]+)",
+    re.IGNORECASE,
+)
+# Every ENGINE = <name> occurrence (case-insensitive; whitespace/newline tolerant).
+_ENGINE_RE = re.compile(r"engine\s*=\s*([A-Za-z0-9_]+)", re.IGNORECASE)
+
+
+def _strip_yaml_comment(line: str) -> str:
+    """Remove a YAML inline/full-line ``#`` comment (best-effort, ignores quoting)."""
+    if line.lstrip().startswith("#"):
+        return ""
+    return re.sub(r"\s+#.*$", "", line)
+
+
+def effective_replicas(values_file: str) -> int:
+    """Return clickhouse.cluster.layout.replicasCount (path-scoped), default 1."""
+    if not os.path.isfile(values_file):
+        return 1
+    stack: list[tuple[int, str]] = []  # (indent, key) for the current ancestry
+    with open(values_file, encoding="utf-8") as fh:
+        for raw in fh:
+            line = _strip_yaml_comment(raw.rstrip("\n"))
+            if not line.strip():
+                continue
+            m = _KEY_RE.match(line)
+            if not m:
+                continue
+            indent, key, value = len(m.group(1)), m.group(2), m.group(3)
+            # Pop ancestors that are siblings/deeper than this key.
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+            parents = tuple(k for _, k in stack)
+            if key == "replicasCount" and parents == _LAYOUT_PATH:
+                vm = re.match(r"[\"']?(\d+)", value)
+                if vm:
+                    return int(vm.group(1), 10)  # base-10: tolerate leading zeros
+            stack.append((indent, key))
+    return 1
+
+
+def _strip_sql_comments(sql: str) -> str:
+    sql = re.sub(r"/\*.*?\*/", " ", sql, flags=re.DOTALL)  # /* block */
+    sql = re.sub(r"--[^\n]*", " ", sql)                     # -- line
+    return sql
+
+
+def _is_nonreplicated_mergetree(engine: str) -> bool:
+    e = engine.lower()
+    return e.endswith("mergetree") and not e.startswith("replicated")
+
+
+def non_replicated_tables(sql: str) -> list[tuple[str, str]]:
+    """Return [(table_name, engine)] for non-replicated MergeTree-family tables."""
+    offenders: list[tuple[str, str]] = []
+    for stmt in _strip_sql_comments(sql).split(";"):
+        if "engine" not in stmt.lower():
+            continue
+        name_m = _CREATE_RE.search(stmt)
+        name = name_m.group(1) if name_m else "?"
+        for eng in _ENGINE_RE.findall(stmt):
+            if _is_nonreplicated_mergetree(eng):
+                offenders.append((name, eng))
+    return offenders
+
+
+def scan_schemas(schema_dir: str) -> list[tuple[str, str, str]]:
+    """Return [(file, table, engine)] across schema_dir/*.sql (empty if none)."""
+    offenders: list[tuple[str, str, str]] = []
+    for path in sorted(glob.glob(os.path.join(schema_dir, "*.sql"))):
+        with open(path, encoding="utf-8") as fh:
+            for name, eng in non_replicated_tables(fh.read()):
+                offenders.append((os.path.basename(path), name, eng))
+    return offenders
+
+
+def _resolve_values_file(env: str) -> str | None:
+    base = os.path.join(REPO_ROOT, "environments", env, "clickhouse.yaml")
+    if os.path.isfile(base):
+        return base
+    if os.path.isfile(base + ".example"):
+        return base + ".example"
+    return None
+
+
+def main(argv: list[str]) -> int:
+    env = argv[1] if len(argv) > 1 else "homelab"
+    warn_only = os.environ.get("WARN_ONLY", "0") == "1"
+    schema_dir = os.path.join(REPO_ROOT, "schemas")
+
+    print(f"=== Replication-topology guard: environment '{env}' ===")
+
+    values_file = _resolve_values_file(env)
+    if values_file is None:
+        print(f"SKIP: no clickhouse values for '{env}' "
+              f"(looked for environments/{env}/clickhouse.yaml[.example]).")
+        return 0
+
+    replicas = effective_replicas(values_file)
+    rel = os.path.relpath(values_file, REPO_ROOT)
+    print(f"  layout.replicasCount = {replicas}  (from {rel})")
+
+    if replicas <= 1:
+        print("OK: replicasCount <= 1 — single-replica topology needs no replicated engines.")
+        return 0
+
+    offenders = scan_schemas(schema_dir)
+    if not offenders:
+        print(f"OK: replicasCount={replicas} and all schema tables use Replicated* engines.")
+        return 0
+
+    print(f"\nFound replicasCount={replicas} with NON-replicated table engine(s):")
+    for fname, table, engine in offenders:
+        print(f"  - {table:<28} {engine:<24} ({fname})")
+    print(
+        "\nreplicasCount > 1 gives real HA only with Replicated* engines. Either:\n"
+        f"  (a) set clickhouse.cluster.layout.replicasCount: 1 for '{env}' until schemas "
+        "are replicated, or\n"
+        "  (b) convert the tables above to Replicated*MergeTree (and add a Distributed "
+        "table for cross-shard reads)."
+    )
+
+    if warn_only:
+        print("\nWARNING (WARN_ONLY=1): reported, not failing.")
+        return 0
+    print("\nFAILED: replicated topology declared but tables are not replicated.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
Adds a CI guard that fails when an environment declares
`clickhouse.cluster.layout.replicasCount > 1` while any schema in `schemas/*.sql`
uses a non-replicated MergeTree-family engine.

## Why
`replicasCount > 1` only provides real data HA if tables use a `Replicated*`
engine. With plain `MergeTree`/`ReplacingMergeTree` the operator provisions N
replica pods holding **independent, diverging** copies — so `replicasCount > 1`
buys nothing but a false sense of HA. (Confirmed: the Altinity operator does not
auto-convert engines, and `SYSTEM RESTORE REPLICA` errors on non-replicated
tables.) This guard makes that mismatch a loud, deploy-time failure.

## What
- **`scripts/validate_replication_topology.py`** (stdlib only) — resolves an env's
  layout `replicasCount` (path-scoped to `clickhouse.cluster.layout`) and scans
  `schemas/*.sql`; exits non-zero on a violation, listing the offending tables.
  `WARN_ONLY=1` downgrades to a non-failing warning.
- **`.github/workflows/replication-topology.yml`** — hard-checks `homelab`
  (passes: 1×1), advisory warn-only lint of the `corp.example` template, and runs
  the unit tests.
- **`scripts/tests/test_validate_replication_topology.py`** — 26 cases.

## Detection robustness
Hardened against false negatives found by adversarial testing: case-insensitive
keywords (`Engine`/`engine`), multiline `ENGINE` clauses, multiple statements per
line, `/* */` block comments, path-scoped + quoted + leading-zero `replicasCount`,
and empty/absent schema dirs.

## Test evidence
- `pytest scripts/tests` → **26 passed**.
- `homelab` → OK (exit 0); `corp.example` → flags all 6 tables (exit 1);
  `macbook` → SKIP (no clickhouse.yaml).

## Note — corp.example currently violates the invariant
`corp.example` declares `replicasCount: 2` with non-replicated schemas, so it is
checked **warn-only** for now (it's a template, not a deployable env). To make it
a hard check, corp should either set `replicasCount: 1` until the schemas are
replicated, or convert the schemas to `Replicated*` engines (+ a `Distributed`
table). Happy to do either as a follow-up.

## Related
- Keeper chart PDB: #73 · Keeper migration runbook: #68 · Keeper chart/wiring: #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)