### PR TITLE
feat(clickhouse-keeper): derive quorum-correct PDB maxUnavailable from replicaCount

### DIFF
--- a/charts/clickhouse-keeper/Chart.yaml
+++ b/charts/clickhouse-keeper/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: clickhouse-keeper
 description: ClickHouse Keeper — ZooKeeper-compatible coordination service for ClickHouse replication
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "24.8"

--- a/charts/clickhouse-keeper/templates/poddisruptionbudget.yaml
+++ b/charts/clickhouse-keeper/templates/poddisruptionbudget.yaml
@@ -10,9 +10,15 @@ spec:
   # Cap how many keeper pods a *voluntary* disruption (node drain, rolling node
   # upgrade) can take down at once. With soft anti-affinity on a 2-node cluster the
   # 3 replicas pack as 2+1, so without this a drain of the 2-pod node would evict
-  # two replicas together and break the raft quorum. maxUnavailable: 1 keeps a
-  # 2-of-3 majority during drains.
+  # two replicas together and break the raft quorum.
+  # When maxUnavailable is unset (null), derive the quorum-correct value
+  # ceil(n/2) - 1 from replicaCount (3 -> 1, 5 -> 2, 2 -> 0, 1 -> 0) so the budget
+  # cannot silently permit a quorum-fatal eviction when replicaCount changes.
+  {{- if kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ max 0 (sub (div (add .Values.replicaCount 1) 2) 1) }}
+  {{- else }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "clickhouse-keeper.selectorLabels" . | nindent 6 }}

--- a/charts/clickhouse-keeper/tests/poddisruptionbudget_test.yaml
+++ b/charts/clickhouse-keeper/tests/poddisruptionbudget_test.yaml
@@ -16,8 +16,14 @@ tests:
       - equal:
           path: spec.maxUnavailable
           value: 1
-      - isNotEmpty:
+      # Pin the selector content: it must equal the selectorLabels the keeper
+      # pods carry. A drift (e.g. switching to the labels helper, which adds
+      # managed-by) would match zero pods and silently disable protection.
+      - equal:
           path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: clickhouse-keeper
+            app.kubernetes.io/instance: RELEASE-NAME
 
   - it: is not rendered when disabled
     set:
@@ -33,3 +39,37 @@ tests:
       - equal:
           path: spec.maxUnavailable
           value: 2
+
+  # Auto-derivation: ceil(n/2) - 1 keeps a raft majority for any replicaCount.
+  - it: derives maxUnavailable 2 for a 5-replica quorum
+    set:
+      replicaCount: 5
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+
+  - it: derives maxUnavailable 0 for 2 replicas (no fault tolerance to spend)
+    set:
+      replicaCount: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 0
+
+  - it: derives maxUnavailable 0 for a single replica
+    set:
+      replicaCount: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 0
+
+  - it: explicit maxUnavailable overrides the derivation
+    set:
+      replicaCount: 5
+      podDisruptionBudget.maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1

--- a/charts/clickhouse-keeper/values.yaml
+++ b/charts/clickhouse-keeper/values.yaml
@@ -43,9 +43,10 @@ affinity: {}
 # budget stays consumed, and `kubectl drain` blocks indefinitely. Use
 # node-independent (network) storage, or keep a spare schedulable node.
 # NOTE: on a single-node cluster a PDB cannot protect anything (node loss takes
-# all replicas anyway) and only wedges `kubectl drain` of that node after the
-# first eviction. Set enabled: false there (see environments/homelab/keeper.yaml)
-# or drain with --disable-eviction.
+# all replicas anyway) and only wedges `kubectl drain` of that node (immediately
+# when the derived budget is 0, or after the first eviction otherwise). Set
+# enabled: false there (see environments/homelab/keeper.yaml) or drain with
+# --disable-eviction.
 podDisruptionBudget:
   enabled: true
   maxUnavailable: null

--- a/charts/clickhouse-keeper/values.yaml
+++ b/charts/clickhouse-keeper/values.yaml
@@ -28,10 +28,24 @@ affinity: {}
 # (node drains, rolling node upgrades). On a small (1-2 node) cluster the soft
 # anti-affinity above packs replicas onto fewer nodes (e.g. 2+1 on two nodes), so
 # without a PDB a single `kubectl drain` can evict two keeper pods at once and
-# break the quorum. maxUnavailable: 1 keeps a 2-of-3 majority during drains.
+# break the quorum.
+# maxUnavailable: null (default) auto-derives the quorum-correct ceil(n/2) - 1
+# from replicaCount (3 -> 1, 5 -> 2, 2 -> 0, 1 -> 0), so changing replicaCount
+# cannot silently leave a budget that permits a quorum-fatal eviction. Set an
+# explicit integer only to override the derived value — and recompute it if you
+# change replicaCount.
 # NOTE: a PDB only blocks *voluntary* evictions — it cannot protect against an
 # *unplanned* loss of the node hosting two pods. True node-failure HA needs a
 # third schedulable node (and ideally hard anti-affinity via `affinity` above).
+# NOTE: the PDB is only drain-safe when an evicted pod can become Ready again
+# elsewhere. With node-bound storage (local-path/hostpath PVs) the RWO data PVC
+# cannot follow the pod to another node: the replacement stays Pending, the
+# budget stays consumed, and `kubectl drain` blocks indefinitely. Use
+# node-independent (network) storage, or keep a spare schedulable node.
+# NOTE: on a single-node cluster a PDB cannot protect anything (node loss takes
+# all replicas anyway) and only wedges `kubectl drain` of that node after the
+# first eviction. Set enabled: false there (see environments/homelab/keeper.yaml)
+# or drain with --disable-eviction.
 podDisruptionBudget:
   enabled: true
-  maxUnavailable: 1
+  maxUnavailable: null

--- a/environments/homelab/keeper.yaml
+++ b/environments/homelab/keeper.yaml
@@ -10,3 +10,10 @@
 replicaCount: 3
 storage:
   size: 5Gi
+
+# Homelab is a single-node cluster: a PDB cannot protect the quorum there (node
+# loss takes all replicas anyway) and would wedge `kubectl drain` of the only
+# node after the first eviction. Keep it off; the chart default (on, with a
+# quorum-correct derived maxUnavailable) is meant for multi-node clusters.
+podDisruptionBudget:
+  enabled: false


### PR DESCRIPTION
## Summary

Fast-follow for the 4 non-blocking findings from the [PR #73 adversarial review](https://github.com/YoonsungNam/gpu-mon/pull/73#issuecomment-4657559340):

| # | Finding | Fix |
|---|---|---|
| 1 | `maxUnavailable` decoupled from `replicaCount` (quorum-fatal at n=2, over-restrictive at n=5) | `maxUnavailable: null` now auto-derives `ceil(n/2) - 1` in the template (3→1, 5→2, 2→0, 1→0); explicit integer still overrides |
| 2 | RWO + node-bound storage drain hang undocumented | `values.yaml` NOTE: drain-safety needs node-independent storage or a spare node |
| 3 | Default-on PDB wedges single-node drains | `values.yaml` NOTE + homelab keeper overrides set `podDisruptionBudget.enabled: false` (homelab is single-node; keeper there is opt-in testing only) |
| 4 | Test asserted only `isNotEmpty` on the selector | Pins `spec.selector.matchLabels` content; +3 derivation tests, +1 override test |

**No behavior change for shipped defaults:** `replicaCount: 3` still renders `maxUnavailable: 1` (verified for corp.example values — selector intact). Chart `0.2.0 → 0.3.0`.

## Test evidence (local)

- `helm unittest`: **27 passed** (PDB suite 3 → 7 tests)
- `helm lint`: clean
- Template sweep: `replicaCount` 1..5 renders `maxUnavailable` 0,0,1,1,2; explicit override (n=5, set 1 → 1); `enabled: false` renders 0 documents
- `helmfile -e homelab --state-values-set clickhouse_keeper.enabled=true template`: keeper StatefulSet renders, PDB absent (homelab override)
- corp.example keeper values: PDB renders `maxUnavailable: 1` with correct selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)