### PR TITLE
docs(clickhouse-keeper): runbook PDB note reflects derived maxUnavailable

### DIFF
--- a/docs/clickhouse-keeper-migration.md
+++ b/docs/clickhouse-keeper-migration.md
@@ -125,7 +125,8 @@ Do **not** proceed until exactly one `leader` and two `follower` nodes are repor
 > (preferred) anti-affinity, so on two nodes the three replicas pack as **2+1**. That schedules
 > fine and survives *pod*-level disruption (a pod crash, a rolling restart, or a drain of the
 > 1-pod node), but losing the node that holds **two** pods drops you to one and **breaks the
-> raft quorum**. The chart ships a `PodDisruptionBudget` (`maxUnavailable: 1`, gpu-mon #73) so a
+> raft quorum**. The chart ships a `PodDisruptionBudget` (`maxUnavailable` derived from
+> `replicaCount` as ceil(n/2) − 1 — `1` for the 3-replica default; gpu-mon #73/#75) so a
 > `kubectl drain` / rolling node upgrade keeps a 2-of-3 majority — but a PDB only blocks
 > *voluntary* evictions; it cannot protect against an *unplanned* loss of the 2-pod node. For
 > true node-failure HA, run keeper on **≥3 schedulable nodes** and switch to hard anti-affinity


### PR DESCRIPTION
One-line follow-up from the [PR #75 verification](https://github.com/YoonsungNam/gpu-mon/pull/75#issuecomment-4665910865) (finding 2): the migration runbook still described the PDB as shipping a fixed `maxUnavailable: 1`. Since #75 the value is derived from `replicaCount` (`ceil(n/2) − 1`); the rendered value for the runbook's 3-replica topology is unchanged at `1`.

Docs-only; no runtime impact. Split from #75 per the per-layer PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)